### PR TITLE
AIO Plugin should provide hint on what to do with 'Upload in progress'

### DIFF
--- a/src/commands/aem/rde/install.js
+++ b/src/commands/aem/rde/install.js
@@ -157,7 +157,12 @@ class DeployCommand extends BaseCommand {
     } catch (err) {
       progressBar.stop();
       spinner.stop();
-      cli.log(err);
+      if (err.endsWith('Concurrent modification')) {
+        cli.log('Your RDE is waiting for the upload of a previous invocation of the "install" command.');
+        cli.log('You can ignore this by using the "--force" flag.');
+      } else {
+        cli.log(err);
+      }
     }
   }
 }

--- a/src/lib/cloud-sdk-api.js
+++ b/src/lib/cloud-sdk-api.js
@@ -130,6 +130,10 @@ class CloudSdkAPI {
     return await fetch(url, options);
   }
 
+  async _createError(response) {
+    return `Error: ${response.status} - ${(await response.text())}`
+  }
+
   async getLogs(id) {
     return await this._doGet(`/runtime/updates/${id}/logs`)
   }
@@ -160,7 +164,7 @@ class CloudSdkAPI {
       return await this._putUpdate(changeId, deploymentCallback);
     } else {
       uploadCallbacks.abort()
-      throw `Error: ${result.status} - ${result.statusText}`
+      throw await this._createError(result);
     }
   }
 
@@ -214,7 +218,7 @@ class CloudSdkAPI {
         return await this._putUpdate(changeId, deploymentCallback);
       } else {
         uploadCallbacks.abort()
-        throw `Error: ${result.status} - ${result.statusText}`
+        throw await this._createError(result);
       }
     } else {
       throw Error("Can not get file size from head request");
@@ -230,7 +234,7 @@ class CloudSdkAPI {
     if (change.status === 200) {
       return await change.json();
     } else {
-      throw `Error: ${change.status} - ${change.statusText}`
+      throw await this._createError(change);
     }
   }
 
@@ -242,7 +246,7 @@ class CloudSdkAPI {
     if (change.status === 200) {
       return await change.json();
     } else {
-      throw `Error: ${change.status} - ${change.statusText}`
+      throw await this._createError(change);
     }
   }
 
@@ -251,7 +255,7 @@ class CloudSdkAPI {
     if (response.status === 200) {
       return await (response.json());
     } else {
-      throw `Error: ${response.status} - ${response.statusText}`
+      throw await this._createError(response);
     }
   }
 
@@ -311,14 +315,14 @@ class CloudSdkAPI {
         throw `Error: no namespace found`;
       }
     } else {
-      throw `Error: ${nameSpaceRequest.status} - ${nameSpaceRequest.statusText}`;
+      throw await this._createError(nameSpaceRequest);
     }
   }
 
   async _checkRDE() {
     const response = await this.getArtifacts(`limit=0`)
     if (response.status !== 200) {
-        throw `Error: ${response.status} - ${response.statusText}`
+      throw await this._createError(response);
     }
   }
 


### PR DESCRIPTION
When installing an artifact from a local file, the file needs to be uploaded. A signed URL with a lifetime of a few minutes is provided for the upload. In case the upload is interrupted or is simply not performed/confirmed, the RDE aio plugin needs to wait until the URL expires, before the next install can be performed. However, it is possible to use the `--force` flag in order to skip the wait time. The error message displayed in this scenario should inform the user of the possibility to use the `--force` flag.
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
