### PR TITLE
simplify and refactor tests

### DIFF
--- a/src/commands/aem/rde/history.js
+++ b/src/commands/aem/rde/history.js
@@ -15,9 +15,9 @@ const { BaseCommand, cli } = require('../../../lib/base-command');
 const rdeUtils = require('../../../lib/rde-utils');
 const spinner = require('ora')();
 
-class ChangesCommand extends BaseCommand {
+class HistoryCommand extends BaseCommand {
   async run() {
-    const { args } = await this.parse(ChangesCommand);
+    const { args } = await this.parse(HistoryCommand);
     try {
       if (args.id === undefined) {
         spinner.start('fetching updates');
@@ -54,7 +54,7 @@ class ChangesCommand extends BaseCommand {
   }
 }
 
-Object.assign(ChangesCommand, {
+Object.assign(HistoryCommand, {
   description: 'Get a list of the updates done to the current rde.',
   args: [
     {
@@ -67,4 +67,4 @@ Object.assign(ChangesCommand, {
   aliases: [],
 });
 
-module.exports = ChangesCommand;
+module.exports = HistoryCommand;

--- a/test/commands/aem/rde/history.test.js
+++ b/test/commands/aem/rde/history.test.js
@@ -47,19 +47,19 @@ const stubbedCloudSdkMethods = {
   })
 };
 
-describe('HistoryCommand', () => {
+describe('HistoryCommand', function() {
 
   setupLogCapturing(sinon, cli)
 
-  describe('#run', () => {
+  describe('#run', function() {
     let [command, cloudSdkApiStub] = createCloudSdkAPIStub(sinon, new HistoryCommand([], null), stubbedCloudSdkMethods);
 
-    it('should call getChanges() exactly once', async () => {
+    it('should call getChanges() exactly once', async function() {
       await command.run();
       assert.ok(cloudSdkApiStub.getChanges.calledOnce);
     });
 
-    it('should produce the correct log output', async () => {
+    it('should produce the correct log output', async function() {
       await command.run();
       assert.equal(cli.log.getCapturedLogOutput(),
           "#6: install OK - done by undefined at undefined\n" +
@@ -67,17 +67,17 @@ describe('HistoryCommand', () => {
     });
   });
 
-  describe('#run with id', () => {
+  describe('#run with id', function() {
     let [command, cloudSdkApiStub] = createCloudSdkAPIStub(sinon, new HistoryCommand(['123'], null), stubbedCloudSdkMethods);
 
-    it('called the right remote API methods', async () => {
+    it('called the right remote API methods', async function() {
       await command.run();
       assert.ok(cloudSdkApiStub.getChange.calledOnceWithExactly('123'));
       assert.ok(cloudSdkApiStub.getLogs.calledOnceWithExactly('123'));
       assert.ok(cloudSdkApiStub.getChange.calledBefore(cloudSdkApiStub.getLogs));
     });
 
-    it('should produce the correct log output', async () => {
+    it('should produce the correct log output', async function() {
       await command.run();
       assert.equal(cli.log.getCapturedLogOutput(),
           "#123: install OK - done by undefined at undefined\n" +

--- a/test/commands/aem/rde/history.test.js
+++ b/test/commands/aem/rde/history.test.js
@@ -72,8 +72,9 @@ describe('HistoryCommand', () => {
 
     it('called the right remote API methods', async () => {
       await command.run();
-      assert.ok(cloudSdkApiStub.getChange.calledOnce)
-      assert.ok(cloudSdkApiStub.getLogs.calledOnce)
+      assert.ok(cloudSdkApiStub.getChange.calledOnceWithExactly('123'));
+      assert.ok(cloudSdkApiStub.getLogs.calledOnceWithExactly('123'));
+      assert.ok(cloudSdkApiStub.getChange.calledBefore(cloudSdkApiStub.getLogs));
     });
 
     it('should produce the correct log output', async () => {

--- a/test/commands/aem/rde/reset.test.js
+++ b/test/commands/aem/rde/reset.test.js
@@ -1,24 +1,20 @@
 const assert = require('assert');
+const sinon = require('sinon').createSandbox();
 const ResetCommand = require('../../../../src/commands/aem/rde/reset.js');
+const {createCloudSdkAPIStub, setupLogCapturing} = require("./util");
+const {cli} = require("../../../../src/lib/base-command");
 
-const mockCloudSDKAPI = {};
-mockCloudSDKAPI.resetEnvCalled = false;
-mockCloudSDKAPI.resetEnv = function () {
-  this.resetEnvCalled = true;
-};
+describe('ResetCommand', () => {
 
-const mockWithCloudSdk = function (fn) {
-  return fn(mockCloudSDKAPI);
-};
+  setupLogCapturing(sinon, cli);
 
-describe('ResetCommand', function () {
-  describe('#run', async function () {
-    const rc = new ResetCommand();
-    rc.withCloudSdk = mockWithCloudSdk.bind(rc);
-
-    rc.run();
-    it('cloudSDKAPI.resetEnv() has been called', function () {
-      assert.ok(mockCloudSDKAPI.resetEnvCalled);
+  describe('#run', () => {
+    it('cloudSDKAPI.resetEnv() has been called', async () => {
+      let [command, cloudSdkApiStub] = createCloudSdkAPIStub(sinon, new ResetCommand([], null), {
+        resetEnv: () => {}
+      })
+      await command.run();
+      assert.ok(cloudSdkApiStub.resetEnv.calledOnce);
     });
   });
 });

--- a/test/commands/aem/rde/reset.test.js
+++ b/test/commands/aem/rde/reset.test.js
@@ -4,12 +4,12 @@ const ResetCommand = require('../../../../src/commands/aem/rde/reset.js');
 const {createCloudSdkAPIStub, setupLogCapturing} = require("./util");
 const {cli} = require("../../../../src/lib/base-command");
 
-describe('ResetCommand', () => {
+describe('ResetCommand', function() {
 
   setupLogCapturing(sinon, cli);
 
-  describe('#run', () => {
-    it('cloudSDKAPI.resetEnv() has been called', async () => {
+  describe('#run', function() {
+    it('cloudSDKAPI.resetEnv() has been called', async function() {
       let [command, cloudSdkApiStub] = createCloudSdkAPIStub(sinon, new ResetCommand([], null), {
         resetEnv: () => {}
       })

--- a/test/commands/aem/rde/restart.test.js
+++ b/test/commands/aem/rde/restart.test.js
@@ -1,24 +1,20 @@
 const assert = require('assert');
+const sinon = require('sinon').createSandbox();
 const RestartCommand = require('../../../../src/commands/aem/rde/restart.js');
+const {createCloudSdkAPIStub, setupLogCapturing} = require("./util");
+const {cli} = require("../../../../src/lib/base-command");
 
-const mockCloudSDKAPI = {};
-mockCloudSDKAPI.restartEnvCalled = false;
-mockCloudSDKAPI.restartEnv = function () {
-  this.restartEnvCalled = true;
-};
+describe('RestartCommand', () => {
 
-const mockWithCloudSdk = function (fn) {
-  return fn(mockCloudSDKAPI);
-};
+  setupLogCapturing(sinon, cli);
 
-describe('RestartCommand', function () {
-  describe('#run', async function () {
-    const rc = new RestartCommand();
-    rc.withCloudSdk = mockWithCloudSdk.bind(rc);
-    rc.run();
-
-    it('cloudSDKAPI.restartEnv() has been called', function () {
-      assert.ok(mockCloudSDKAPI.restartEnvCalled);
+  describe('#run', () => {
+    let [command, cloudSdkApiStub] = createCloudSdkAPIStub(sinon, new RestartCommand([], null), {
+      restartEnv: () => {}
+    });
+    it('cloudSDKAPI.restartEnv() has been called', async () => {
+      await command.run();
+      assert.ok(cloudSdkApiStub.restartEnv.calledOnce);
     });
   });
 });

--- a/test/commands/aem/rde/restart.test.js
+++ b/test/commands/aem/rde/restart.test.js
@@ -4,15 +4,15 @@ const RestartCommand = require('../../../../src/commands/aem/rde/restart.js');
 const {createCloudSdkAPIStub, setupLogCapturing} = require("./util");
 const {cli} = require("../../../../src/lib/base-command");
 
-describe('RestartCommand', () => {
+describe('RestartCommand', function() {
 
   setupLogCapturing(sinon, cli);
 
-  describe('#run', () => {
+  describe('#run', function() {
     let [command, cloudSdkApiStub] = createCloudSdkAPIStub(sinon, new RestartCommand([], null), {
       restartEnv: () => {}
     });
-    it('cloudSDKAPI.restartEnv() has been called', async () => {
+    it('cloudSDKAPI.restartEnv() has been called', async function() {
       await command.run();
       assert.ok(cloudSdkApiStub.restartEnv.calledOnce);
     });

--- a/test/commands/aem/rde/status.test.js
+++ b/test/commands/aem/rde/status.test.js
@@ -33,19 +33,19 @@ sinon.stub(Config, 'get')
     .withArgs('cloudmanager_programid').returns('12345')
     .withArgs('cloudmanager_environmentid').returns('54321')
 
-describe('StatusCommand', () => {
+describe('StatusCommand', function() {
 
   setupLogCapturing(sinon, cli);
 
-  describe('#run as textual result', () => {
+  describe('#run as textual result', function() {
     let [command, cloudSdkApiStub] = createCloudSdkAPIStub(sinon, new StatusCommand([], null), stubbedMethods);
 
-    it('should call getArtifacts() exactly once', async () => {
+    it('should call getArtifacts() exactly once', async function() {
       await command.run();
       assert.equal(cloudSdkApiStub.getArtifacts.calledOnce, true);
     });
 
-    it('should produce the correct textual output', async () => {
+    it('should produce the correct textual output', async function() {
       await command.run();
       assert.equal(cli.log.getCapturedLogOutput(),
           "Info for cm-p12345-e54321\n" +
@@ -58,15 +58,15 @@ describe('StatusCommand', () => {
     });
   });
 
-  describe('#run as json result', () => {
+  describe('#run as json result', function() {
     let [command, cloudSdkApiStub] = createCloudSdkAPIStub(sinon, new StatusCommand(['--json'], null), stubbedMethods);
 
-    it('should call getArtifacts() exactly once', async () => {
+    it('should call getArtifacts() exactly once', async function() {
       await command.run();
       assert.equal(cloudSdkApiStub.getArtifacts.calledOnce, true);
     });
 
-    it('should have the expected json result', async () => {
+    it('should have the expected json result', async function() {
       await command.run();
       assert.deepEqual(
         {

--- a/test/commands/aem/rde/util.js
+++ b/test/commands/aem/rde/util.js
@@ -6,13 +6,11 @@ function setupLogCapturing(sinon, cli) {
         cli.log.getCapturedLogOutput = () => cli.log.getCalls().map(i => i.firstArg).join('\n')
     });
 
-    beforeEach(() => {
-        cli.log.resetHistory();
-    });
+    // Resets the internal state of all fakes created through sandbox, see https://sinonjs.org/releases/latest/sandbox/#sandboxreset
+    beforeEach(sinon.reset);
 
-    after(() => {
-        sinon.restore();
-    });
+    // Restores all fakes created through sandbox, see https://sinonjs.org/releases/latest/sandbox/#sandboxrestore
+    after(sinon.restore);
 }
 
 function createCloudSdkAPIStub(sinon, command, stubbedMethods) {

--- a/test/commands/aem/rde/util.js
+++ b/test/commands/aem/rde/util.js
@@ -1,0 +1,31 @@
+const {CloudSdkAPI} = require("../../../../src/lib/cloud-sdk-api");
+
+function setupLogCapturing(sinon, cli) {
+    before(() => {
+        sinon.replace(cli, 'log', sinon.fake());
+        cli.log.getCapturedLogOutput = () => cli.log.getCalls().map(i => i.firstArg).join('\n')
+    });
+
+    beforeEach(() => {
+        cli.log.resetHistory();
+    });
+
+    after(() => {
+        sinon.restore();
+    });
+}
+
+function createCloudSdkAPIStub(sinon, command, stubbedMethods) {
+    let cloudSdkApiStub = sinon.createStubInstance(CloudSdkAPI);
+    Object.keys(stubbedMethods).forEach(methodName =>
+        sinon.replace(cloudSdkApiStub, methodName, sinon.fake(stubbedMethods[methodName]))
+    );
+
+    sinon.replace(command, 'withCloudSdk', fn => fn(cloudSdkApiStub));
+    return [command, cloudSdkApiStub];
+}
+
+module.exports = {
+    setupLogCapturing,
+    createCloudSdkAPIStub
+}


### PR DESCRIPTION
Simplify test cases using the "sinon" library for stubbing/mocking instead of creating stubs/mocks manually.