### PR TITLE
colorize log output and make logs more fluid

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -12,12 +12,26 @@
 'use strict';
 
 /**
- * @param seconds
+ * Sleep a defined number of seconds.
+ * @param seconds The number of seconds to sleep.
+ * @return promise for the sleep duration
  */
 function sleepSeconds(seconds) {
-  return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+  return sleepMillis(seconds * 1000);
+}
+
+/**
+ * Sleep a defined number of milliseconds.
+ * @param millis The number of milliseconds to sleep.
+ * @return promise for the sleep duration
+ */
+function sleepMillis(millis) {
+  return millis === 0
+    ? Promise.resolve()
+    : new Promise((resolve) => setTimeout(resolve, millis));
 }
 
 module.exports = {
   sleepSeconds,
+  sleepMillis,
 };

--- a/test/commands/aem/rde/history.test.js
+++ b/test/commands/aem/rde/history.test.js
@@ -6,31 +6,29 @@ const HistoryCommand = require('../../../../src/commands/aem/rde/history.js');
 const { setupLogCapturing, createCloudSdkAPIStub } = require('../../../util');
 
 const stubbedCloudSdkMethods = {
-  getChanges: sinon.fake(() =>
-    Object.create({
-      status: 200,
-      json: function () {
-        return {
-          items: [
-            {
-              updateId: 6,
-              action: 'install',
-              status: 'OK',
-              metadata: {},
-              timestamps: {},
-            },
-            {
-              updateId: 8,
-              action: 'delete',
-              status: 'OK',
-              metadata: {},
-              timestamps: {},
-            },
-          ],
-        };
-      },
-    })
-  ),
+  getChanges: {
+    status: 200,
+    json: function () {
+      return {
+        items: [
+          {
+            updateId: 6,
+            action: 'install',
+            status: 'OK',
+            metadata: {},
+            timestamps: {},
+          },
+          {
+            updateId: 8,
+            action: 'delete',
+            status: 'OK',
+            metadata: {},
+            timestamps: {},
+          },
+        ],
+      };
+    },
+  },
   getChange: (id) =>
     Object.create({
       status: 200,
@@ -51,15 +49,19 @@ const stubbedCloudSdkMethods = {
     }),
 };
 
+let command, cloudSdkApiStub;
+
 describe('HistoryCommand', function () {
   setupLogCapturing(sinon, cli);
 
   describe('#getChanges', function () {
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new HistoryCommand([], null),
-      stubbedCloudSdkMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new HistoryCommand([], null),
+        stubbedCloudSdkMethods
+      );
+    });
 
     it('should be called exactly once', async function () {
       await command.run();
@@ -77,11 +79,13 @@ describe('HistoryCommand', function () {
   });
 
   describe('#getChange', function () {
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new HistoryCommand(['123'], null),
-      stubbedCloudSdkMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new HistoryCommand(['123'], null),
+        stubbedCloudSdkMethods
+      );
+    });
 
     it('called the right remote API methods', async function () {
       await command.run();

--- a/test/commands/aem/rde/inspect/inventory.test.js
+++ b/test/commands/aem/rde/inspect/inventory.test.js
@@ -8,66 +8,58 @@ const {
 } = require('../../../../util.js');
 const chalk = require('chalk');
 
-const errorObj = Object.assign(
-  {},
-  {
-    status: 404,
-    statusText: 'Test error message',
-  }
-);
+const errorObj = Object.create({
+  status: 404,
+  statusText: 'Test error message',
+});
 
 const stubbedThrowErrorMethod = () => {
   throw new Error(errorObj.statusText);
 };
 
 const stubbedMethods = {
-  getInventory: async () =>
-    Object.assign(
-      {},
-      {
-        status: 200,
-        json: async () =>
-          Object.assign(
-            {},
-            {
-              id: 'test',
-              format: 'TEXT',
-              contents: 'test',
-            }
-          ),
-      }
-    ),
+  getInventory: {
+    status: 200,
+    json: async () =>
+      Object.assign(
+        {},
+        {
+          id: 'test',
+          format: 'TEXT',
+          contents: 'test',
+        }
+      ),
+  },
 
-  getInventories: async () =>
-    Object.assign(
-      {},
-      {
-        status: 200,
-        json: async () =>
-          Object.assign(
-            {},
-            {
-              status: '200',
-              items: [
-                { id: 'test1', format: 'TEXT' },
-                { id: 'test2', format: 'TEXT' },
-                { id: 'test3', format: 'TEXT' },
-              ],
-            }
-          ),
-      }
-    ),
+  getInventories: {
+    status: 200,
+    json: async () =>
+      Object.assign(
+        {},
+        {
+          status: '200',
+          items: [
+            { id: 'test1', format: 'TEXT' },
+            { id: 'test2', format: 'TEXT' },
+            { id: 'test3', format: 'TEXT' },
+          ],
+        }
+      ),
+  },
 };
 
+let command, cloudSdkApiStub;
 describe('Inventory', function () {
   setupLogCapturing(sinon, cli);
 
   describe('#getInventories', function () {
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new Inventory([], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new Inventory([], null),
+        stubbedMethods
+      );
+    });
 
     it('Should be called exactly once', async function () {
       await command.run();
@@ -147,11 +139,13 @@ describe('Inventory', function () {
 
   describe('#getInventory', function () {
     const reqId = 'test';
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new Inventory([reqId], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new Inventory([reqId], null),
+        stubbedMethods
+      );
+    });
 
     it('Should be called exactly once', async function () {
       await command.run();

--- a/test/commands/aem/rde/inspect/osgi-bundles.test.js
+++ b/test/commands/aem/rde/inspect/osgi-bundles.test.js
@@ -98,15 +98,18 @@ const stubbedMethods = {
     ),
 };
 
+let command, cloudSdkApiStub;
 describe('OsgiBundlesCommand', function () {
   setupLogCapturing(sinon, cli);
 
   describe('#getOsgiBundles', function () {
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new OsgiBundlesCommand([], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new OsgiBundlesCommand([], null),
+        stubbedMethods
+      );
+    });
 
     it('Should be called exactly once', async function () {
       await command.run();
@@ -184,11 +187,13 @@ describe('OsgiBundlesCommand', function () {
 
   describe('#getOsgiBundle', function () {
     const reqId = 'com.adobe.aem.test';
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new OsgiBundlesCommand([reqId], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new OsgiBundlesCommand([reqId], null),
+        stubbedMethods
+      );
+    });
 
     it('Should be called exactly once', async function () {
       await command.run();

--- a/test/commands/aem/rde/inspect/osgi-components.test.js
+++ b/test/commands/aem/rde/inspect/osgi-components.test.js
@@ -135,15 +135,18 @@ const stubbedMethods = {
     ),
 };
 
+let command, cloudSdkApiStub;
 describe('OsgiComponentsCommand', function () {
   setupLogCapturing(sinon, cli);
 
   describe('#getOsgiComponents', function () {
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new OsgiComponentsCommand([], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new OsgiComponentsCommand([], null),
+        stubbedMethods
+      );
+    });
 
     it('Should be called exactly once', async function () {
       await command.run();
@@ -221,11 +224,13 @@ describe('OsgiComponentsCommand', function () {
 
   describe('#getOsgiComponent', function () {
     const reqId = 'com.adobe.aem.test';
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new OsgiComponentsCommand([reqId], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new OsgiComponentsCommand([reqId], null),
+        stubbedMethods
+      );
+    });
 
     it('Should be called exactly once', async function () {
       await command.run();

--- a/test/commands/aem/rde/inspect/osgi-configurations.test.js
+++ b/test/commands/aem/rde/inspect/osgi-configurations.test.js
@@ -7,6 +7,7 @@ const {
   createCloudSdkAPIStub,
 } = require('../../../../util.js');
 const chalk = require('chalk');
+const OsgiComponentsCommand = require('../../../../../src/commands/aem/rde/inspect/osgi-components');
 
 const errorObj = Object.assign(
   {},
@@ -76,15 +77,18 @@ const stubbedMethods = {
     ),
 };
 
+let command, cloudSdkApiStub;
 describe('OsgiConfigurationsCommand', function () {
   setupLogCapturing(sinon, cli);
 
   describe('#getOsgiConfigurations', function () {
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new OsgiConfigurationsCommand([], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new OsgiConfigurationsCommand([], null),
+        stubbedMethods
+      );
+    });
 
     it('Should be called exactly once', async function () {
       await command.run();
@@ -160,11 +164,13 @@ describe('OsgiConfigurationsCommand', function () {
 
   describe('#getOsgiConfiguration', function () {
     const reqId = 'com.adobe.aem.test';
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new OsgiConfigurationsCommand([reqId], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new OsgiConfigurationsCommand([reqId], null),
+        stubbedMethods
+      );
+    });
 
     it('Should be called exactly once', async function () {
       await command.run();

--- a/test/commands/aem/rde/inspect/osgi-services.test.js
+++ b/test/commands/aem/rde/inspect/osgi-services.test.js
@@ -7,6 +7,7 @@ const {
   createCloudSdkAPIStub,
 } = require('../../../../util.js');
 const chalk = require('chalk');
+const OsgiConfigurationsCommand = require('../../../../../src/commands/aem/rde/inspect/osgi-configurations');
 
 const errorObj = Object.assign(
   {},
@@ -106,15 +107,18 @@ const stubbedMethods = {
     ),
 };
 
+let command, cloudSdkApiStub;
 describe('OsgiServicesCommand', function () {
   setupLogCapturing(sinon, cli);
 
   describe('#getOsgiServices', function () {
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new OsgiServicesCommand([], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new OsgiServicesCommand([], null),
+        stubbedMethods
+      );
+    });
 
     it('Should be called exactly once', async function () {
       await command.run();
@@ -197,11 +201,13 @@ describe('OsgiServicesCommand', function () {
 
   describe('#getOsgiService', function () {
     const reqId = '0';
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new OsgiServicesCommand([reqId], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new OsgiServicesCommand([reqId], null),
+        stubbedMethods
+      );
+    });
 
     it('Should be called exactly once', async function () {
       await command.run();

--- a/test/commands/aem/rde/inspect/request-logs/disable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/disable.test.js
@@ -38,15 +38,18 @@ const stubbedMethods = {
     ),
 };
 
+let command, cloudSdkApiStub;
 describe('DisableRequestLogsCommand', function () {
   setupLogCapturing(sinon, cli);
 
   describe('#disableRequestLogs', function () {
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new DisableRequestLogsCommand([], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new DisableRequestLogsCommand([], null),
+        stubbedMethods
+      );
+    });
 
     it('Should be called exactly once', async function () {
       await command.run();

--- a/test/commands/aem/rde/inspect/request-logs/enable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/enable.test.js
@@ -35,6 +35,7 @@ const stubbedMethods = {
     ),
 };
 
+let command, cloudSdkApiStub;
 describe('EnableRequestLogsCommand', function () {
   setupLogCapturing(sinon, cli);
 
@@ -43,31 +44,33 @@ describe('EnableRequestLogsCommand', function () {
     const format =
       '%d{dd.MM.yyyy HH:mm:ss.SSS} *%level* [%thread] %logger %msg%n';
     const includePathPatterns = '*test';
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new EnableRequestLogsCommand(
-        [
-          '-i',
-          arg,
-          '-d',
-          arg,
-          '-f',
-          format,
-          '-e',
-          arg,
-          '-p',
-          includePathPatterns,
-          '-i',
-          arg,
-          '-w',
-          arg,
-          '-p',
-          includePathPatterns,
-        ],
-        null
-      ),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new EnableRequestLogsCommand(
+          [
+            '-i',
+            arg,
+            '-d',
+            arg,
+            '-f',
+            format,
+            '-e',
+            arg,
+            '-p',
+            includePathPatterns,
+            '-i',
+            arg,
+            '-w',
+            arg,
+            '-p',
+            includePathPatterns,
+          ],
+          null
+        ),
+        stubbedMethods
+      );
+    });
 
     it('Should pass the includePathPatterns in the right format', async function () {
       await command.run();

--- a/test/commands/aem/rde/inspect/request-logs/index.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/index.test.js
@@ -78,15 +78,18 @@ const stubbedMethods = {
     ),
 };
 
+let command, cloudSdkApiStub;
 describe('RequestLogsCommand', function () {
   setupLogCapturing(sinon, cli);
 
   describe('#getRequestLogs', function () {
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new RequestLogsCommand([], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new RequestLogsCommand([], null),
+        stubbedMethods
+      );
+    });
 
     it('Should be called exactly once', async function () {
       await command.run();
@@ -167,11 +170,13 @@ describe('RequestLogsCommand', function () {
 
   describe('#getRequestLog', function () {
     const reqId = '0';
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new RequestLogsCommand([reqId], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new RequestLogsCommand([reqId], null),
+        stubbedMethods
+      );
+    });
 
     it('Should be called exactly once.', async function () {
       await command.run();

--- a/test/commands/aem/rde/inspect/sling-requests.test.js
+++ b/test/commands/aem/rde/inspect/sling-requests.test.js
@@ -7,6 +7,7 @@ const {
   createCloudSdkAPIStub,
 } = require('../../../../util.js');
 const chalk = require('chalk');
+const OsgiServicesCommand = require('../../../../../src/commands/aem/rde/inspect/osgi-services');
 
 const errorObj = Object.assign(
   {},
@@ -83,15 +84,18 @@ const stubbedMethods = {
     ),
 };
 
+let command, cloudSdkApiStub;
 describe('SlingRequestsCommand', function () {
   setupLogCapturing(sinon, cli);
 
   describe('#getSlingRequests', function () {
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new SlingRequestsCommand([], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new SlingRequestsCommand([], null),
+        stubbedMethods
+      );
+    });
 
     it('Should be called exactly once', async function () {
       await command.run();
@@ -177,11 +181,13 @@ describe('SlingRequestsCommand', function () {
 
   describe('#getSlingRequest', function () {
     const reqId = '1';
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new SlingRequestsCommand([reqId], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new SlingRequestsCommand([reqId], null),
+        stubbedMethods
+      );
+    });
 
     it('Should be called exactly once', async function () {
       await command.run();

--- a/test/commands/aem/rde/reset.test.js
+++ b/test/commands/aem/rde/reset.test.js
@@ -9,7 +9,7 @@ describe('ResetCommand', function () {
 
   describe('#run', function () {
     it('cloudSDKAPI.resetEnv() has been called', async function () {
-      let [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+      const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
         new ResetCommand([], null),
         {

--- a/test/commands/aem/rde/restart.test.js
+++ b/test/commands/aem/rde/restart.test.js
@@ -4,17 +4,21 @@ const RestartCommand = require('../../../../src/commands/aem/rde/restart.js');
 const { setupLogCapturing, createCloudSdkAPIStub } = require('../../../util');
 const { cli } = require('../../../../src/lib/base-command');
 
+let command, cloudSdkApiStub;
 describe('RestartCommand', function () {
   setupLogCapturing(sinon, cli);
 
   describe('#run', function () {
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new RestartCommand([], null),
-      {
-        restartEnv: () => {},
-      }
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new RestartCommand([], null),
+        {
+          restartEnv: () => {},
+        }
+      );
+    });
+
     it('cloudSDKAPI.restartEnv() has been called', async function () {
       await command.run();
       assert.ok(cloudSdkApiStub.restartEnv.calledOnce);

--- a/test/commands/aem/rde/status.test.js
+++ b/test/commands/aem/rde/status.test.js
@@ -7,48 +7,58 @@ const { setupLogCapturing, createCloudSdkAPIStub } = require('../../../util');
 
 const stubbedMethods = {
   getArtifacts: () =>
-    Object.assign(
-      {},
-      {
-        status: 200,
-        json: () =>
-          Object.create({
-            status: 'Ready',
-            items: [
-              {
-                id: 'test-bundle',
-                updateId: '1',
-                service: 'author',
-                type: 'osgi-bundle',
-                metadata: {
-                  name: 'test.all-1.0.0-SNAPSHOT.zip',
-                  bundleSymbolicName: 'test-bundle',
-                  bundleName: 'Test Bundle',
-                  bundleVersion: '1.0.0',
-                },
+    Object.create({
+      status: 200,
+      json: () =>
+        Object.create({
+          status: 'Ready',
+          items: [
+            {
+              id: 'test-bundle',
+              updateId: '1',
+              service: 'author',
+              type: 'osgi-bundle',
+              metadata: {
+                name: 'test.all-1.0.0-SNAPSHOT.zip',
+                bundleSymbolicName: 'test-bundle',
+                bundleName: 'Test Bundle',
+                bundleVersion: '1.0.0',
               },
-            ],
-          }),
-      }
-    ),
+            },
+          ],
+        }),
+    }),
 };
 
-sinon
-  .stub(Config, 'get')
-  .withArgs('cloudmanager_programid')
-  .returns('12345')
-  .withArgs('cloudmanager_environmentid')
-  .returns('54321');
-
+let command, cloudSdkApiStub;
 describe('StatusCommand', function () {
   setupLogCapturing(sinon, cli);
 
+  before(() => {
+    sinon.useFakeTimers();
+  });
+
+  beforeEach(() => {
+    sinon
+      .stub(Config, 'get')
+      .withArgs('cloudmanager_programid')
+      .returns('12345')
+      .withArgs('cloudmanager_environmentid')
+      .returns('54321');
+  });
+
+  afterEach(() => {
+    Config.get.restore();
+  });
+
   describe('#run as textual result', function () {
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new StatusCommand([], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new StatusCommand([], null),
+        stubbedMethods
+      );
+    });
 
     it('should call getArtifacts() exactly once', async function () {
       await command.run();
@@ -71,11 +81,13 @@ describe('StatusCommand', function () {
   });
 
   describe('#run as json result', function () {
-    const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
-      sinon,
-      new StatusCommand(['--json'], null),
-      stubbedMethods
-    );
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new StatusCommand(['--json'], null),
+        stubbedMethods
+      );
+    });
 
     it('should call getArtifacts() exactly once', async function () {
       await command.run();

--- a/test/util.js
+++ b/test/util.js
@@ -15,10 +15,10 @@ function setupLogCapturing(sinon, cli) {
   });
 
   // Resets the internal state of all fakes created through sandbox, see https://sinonjs.org/releases/latest/sandbox/#sandboxreset
-  beforeEach(sinon.reset);
+  afterEach(() => sinon.reset());
 
   // Restores all fakes created through sandbox, see https://sinonjs.org/releases/latest/sandbox/#sandboxrestore
-  after(sinon.restore);
+  after(() => sinon.restore());
 }
 
 /**
@@ -29,13 +29,14 @@ function setupLogCapturing(sinon, cli) {
 function createCloudSdkAPIStub(sinon, command, stubbedMethods) {
   const cloudSdkApiStub = sinon.createStubInstance(CloudSdkAPI);
   if (stubbedMethods) {
-    Object.keys(stubbedMethods).forEach((methodName) =>
-      sinon.replace(
-        cloudSdkApiStub,
-        methodName,
-        sinon.fake(stubbedMethods[methodName])
-      )
-    );
+    Object.keys(stubbedMethods).forEach((methodName) => {
+      const methodOrObject = stubbedMethods[methodName];
+      if (typeof methodOrObject === 'function') {
+        return cloudSdkApiStub[methodName].callsFake(methodOrObject);
+      } else {
+        return cloudSdkApiStub[methodName].returns(methodOrObject);
+      }
+    });
   }
 
   sinon.replace(command, 'withCloudSdk', (fn) => fn(cloudSdkApiStub));


### PR DESCRIPTION
## Description

When tailing logs, the lines are coloured depending on the log level. Furthermore, the tail is made to feel more "fluid" by introducing a small delay between messages.

Fixes #63

## Motivation and Context

This improves the user-experience when tailing logs.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
