### PR TITLE
add 24h check, add quiet mode

### DIFF
--- a/src/commands/aem/rde/delete.js
+++ b/src/commands/aem/rde/delete.js
@@ -13,7 +13,6 @@
 
 const {
   BaseCommand,
-  cli,
   commonFlags,
   Flags,
 } = require('../../../lib/base-command');
@@ -55,7 +54,7 @@ class DeleteCommand extends BaseCommand {
           cloudSdkAPI.delete(artifact.id, flags.force)
         );
         await this.withCloudSdk((cloudSdkAPI) =>
-          loadUpdateHistory(cloudSdkAPI, change.updateId, cli, (done, text) =>
+          loadUpdateHistory(cloudSdkAPI, change.updateId, this, (done, text) =>
             done ? this.spinnerStop() : this.spinnerStart(text)
           )
         );

--- a/src/commands/aem/rde/delete.js
+++ b/src/commands/aem/rde/delete.js
@@ -24,7 +24,6 @@ const {
 } = require('../../../lib/deployment-errors');
 const { codes: internalCodes } = require('../../../lib/internal-errors');
 const { throwAioError } = require('../../../lib/error-helpers');
-const spinner = require('ora')();
 
 class DeleteCommand extends BaseCommand {
   async runCommand(args, flags) {
@@ -39,7 +38,7 @@ class DeleteCommand extends BaseCommand {
         'osgi-config': (config) => config.metadata.configPid === args.id,
       };
 
-      spinner.start(`deleting ${args.id}`);
+      this.spinnerStart(`deleting ${args.id}`);
       const status = await this.withCloudSdk((cloudSdkAPI) =>
         loadAllArtifacts(cloudSdkAPI)
       );
@@ -57,11 +56,11 @@ class DeleteCommand extends BaseCommand {
         );
         await this.withCloudSdk((cloudSdkAPI) =>
           loadUpdateHistory(cloudSdkAPI, change.updateId, cli, (done, text) =>
-            done ? spinner.stop() : spinner.start(text)
+            done ? this.spinnerStop() : this.spinnerStart(text)
           )
         );
       }
-      spinner.stop();
+      this.spinnerStop();
 
       if (artifacts.length === 0) {
         const typeInfo = types.length === 1 ? types[0] : 'artifact';
@@ -72,7 +71,7 @@ class DeleteCommand extends BaseCommand {
         });
       }
     } catch (err) {
-      spinner.stop();
+      this.spinnerStop();
       throwAioError(
         err,
         new internalCodes.INTERNAL_DELETE_ERROR({ messageValues: err })
@@ -108,6 +107,7 @@ Object.assign(DeleteCommand, {
       multiple: false,
       required: false,
     }),
+    quiet: commonFlags.quiet,
   },
   aliases: [],
 });

--- a/src/commands/aem/rde/history.js
+++ b/src/commands/aem/rde/history.js
@@ -29,7 +29,7 @@ class HistoryCommand extends BaseCommand {
           const json = await response.json();
           this.spinnerStop();
           if (json.items.length === 0) {
-            cli.log('There are no updates yet.');
+            this.log('There are no updates yet.');
           } else {
             json.items.forEach(rdeUtils.logChange);
           }

--- a/src/commands/aem/rde/history.js
+++ b/src/commands/aem/rde/history.js
@@ -16,19 +16,18 @@ const rdeUtils = require('../../../lib/rde-utils');
 const { codes: internalCodes } = require('../../../lib/internal-errors');
 const { codes: validationCodes } = require('../../../lib/validation-errors');
 const { throwAioError } = require('../../../lib/error-helpers');
-const spinner = require('ora')();
 
 class HistoryCommand extends BaseCommand {
   async runCommand(args, flags) {
     try {
       if (args.id === undefined) {
-        spinner.start('fetching updates');
+        this.spinnerStart('fetching updates');
         const response = await this.withCloudSdk((cloudSdkAPI) =>
           cloudSdkAPI.getChanges()
         );
         if (response.status === 200) {
           const json = await response.json();
-          spinner.stop();
+          this.spinnerStop();
           if (json.items.length === 0) {
             cli.log('There are no updates yet.');
           } else {
@@ -44,7 +43,7 @@ class HistoryCommand extends BaseCommand {
       } else {
         await this.withCloudSdk((cloudSdkAPI) =>
           rdeUtils.loadUpdateHistory(cloudSdkAPI, args.id, cli, (done, text) =>
-            done ? spinner.stop() : spinner.start(text)
+            done ? this.spinnerStop() : this.spinnerStart(text)
           )
         );
       }
@@ -54,7 +53,7 @@ class HistoryCommand extends BaseCommand {
         new internalCodes.INTERNAL_HISTORY_ERROR({ messageValues: err })
       );
     } finally {
-      spinner.stop();
+      this.spinnerStop();
     }
   }
 }
@@ -74,6 +73,7 @@ Object.assign(HistoryCommand, {
     organizationId: commonFlags.organizationId,
     programId: commonFlags.programId,
     environmentId: commonFlags.environmentId,
+    quiet: commonFlags.quiet,
   },
 });
 

--- a/src/commands/aem/rde/history.js
+++ b/src/commands/aem/rde/history.js
@@ -29,7 +29,7 @@ class HistoryCommand extends BaseCommand {
           const json = await response.json();
           this.spinnerStop();
           if (json.items.length === 0) {
-            this.log('There are no updates yet.');
+            this.doLog('There are no updates yet.');
           } else {
             json.items.forEach(rdeUtils.logChange);
           }

--- a/src/commands/aem/rde/inspect/inventory.js
+++ b/src/commands/aem/rde/inspect/inventory.js
@@ -48,7 +48,7 @@ class InventoryCommand extends BaseCommand {
         if (response.status === 200) {
           const inventory = await response.json();
           if (flags.json) {
-            this.log(JSON.stringify(inventory, null, 2), true);
+            this.doLog(JSON.stringify(inventory, null, 2), true);
           } else {
             this.logInTableFormat([inventory]);
           }
@@ -81,7 +81,7 @@ class InventoryCommand extends BaseCommand {
           minWidth: 20,
         },
       },
-      { printLine: (s) => this.log(s, true) }
+      { printLine: (s) => this.doLog(s, true) }
     );
   }
 }

--- a/src/commands/aem/rde/inspect/inventory.js
+++ b/src/commands/aem/rde/inspect/inventory.js
@@ -34,7 +34,7 @@ class InventoryCommand extends BaseCommand {
           if (flags.json) {
             this.logInJsonArrayFormat(json.items);
           } else {
-            logInTableFormat(json?.items);
+            this.logInTableFormat(json?.items);
           }
         } else {
           throw new internalCodes.UNEXPECTED_API_ERROR({
@@ -48,9 +48,9 @@ class InventoryCommand extends BaseCommand {
         if (response.status === 200) {
           const inventory = await response.json();
           if (flags.json) {
-            cli.log(JSON.stringify(inventory, null, 2));
+            this.log(JSON.stringify(inventory, null, 2), true);
           } else {
-            logInTableFormat([inventory]);
+            this.logInTableFormat([inventory]);
           }
         } else {
           throw new internalCodes.UNEXPECTED_API_ERROR({
@@ -65,25 +65,25 @@ class InventoryCommand extends BaseCommand {
       );
     }
   }
-}
 
-/**
- * @param {object} items - The items displayed as a JSON array.
- */
-function logInTableFormat(items) {
-  cli.table(
-    items,
-    {
-      format: {
-        minWidth: 7,
+  /**
+   * @param {object} items - The items displayed as a JSON array.
+   */
+  logInTableFormat(items) {
+    cli.table(
+      items,
+      {
+        format: {
+          minWidth: 7,
+        },
+        id: {
+          header: 'ID',
+          minWidth: 20,
+        },
       },
-      id: {
-        header: 'ID',
-        minWidth: 20,
-      },
-    },
-    { printLine: (s) => cli.log(s) }
-  );
+      { printLine: (s) => this.log(s, true) }
+    );
+  }
 }
 
 Object.assign(InventoryCommand, {

--- a/src/commands/aem/rde/inspect/inventory.js
+++ b/src/commands/aem/rde/inspect/inventory.js
@@ -102,6 +102,7 @@ Object.assign(InventoryCommand, {
     target: commonFlags.targetInspect,
     include: commonFlags.include,
     json: commonFlags.json,
+    quiet: commonFlags.quiet,
   },
 });
 

--- a/src/commands/aem/rde/inspect/osgi-bundles.js
+++ b/src/commands/aem/rde/inspect/osgi-bundles.js
@@ -33,9 +33,9 @@ class OsgiBundlesCommand extends BaseCommand {
         if (response.status === 200) {
           const json = await response.json();
           if (flags.json) {
-            cli.log(JSON.stringify(json?.items));
+            this.log(JSON.stringify(json?.items), true);
           } else {
-            logInTableFormat(json?.items);
+            this.logInTableFormat(json?.items);
           }
         } else {
           throw new internalCodes.UNEXPECTED_API_ERROR({
@@ -49,9 +49,9 @@ class OsgiBundlesCommand extends BaseCommand {
         if (response.status === 200) {
           const osgiBundle = await response.json();
           if (flags.json) {
-            cli.log(JSON.stringify(osgiBundle, null, 2));
+            this.log(JSON.stringify(osgiBundle, null, 2), true);
           } else {
-            logInTableFormat([osgiBundle]);
+            this.logInTableFormat([osgiBundle]);
           }
         } else {
           throw new internalCodes.UNEXPECTED_API_ERROR({
@@ -68,39 +68,39 @@ class OsgiBundlesCommand extends BaseCommand {
       );
     }
   }
-}
 
-/**
- * @param {object} items - The items selectively displayed in the table.
- */
-function logInTableFormat(items) {
-  cli.table(
-    items,
-    {
-      id: {
-        header: 'ID',
-        minWidth: 20,
+  /**
+   * @param {object} items - The items selectively displayed in the table.
+   */
+  logInTableFormat(items) {
+    cli.table(
+      items,
+      {
+        id: {
+          header: 'ID',
+          minWidth: 20,
+        },
+        name: {
+          minWidth: 7,
+        },
+        version: {
+          minWidth: 7,
+        },
+        state: {
+          minWidth: 7,
+        },
+        stateString: {
+          header: 'State String',
+          minWidth: 7,
+        },
+        startLevel: {
+          header: 'Start Level',
+          minWidth: 7,
+        },
       },
-      name: {
-        minWidth: 7,
-      },
-      version: {
-        minWidth: 7,
-      },
-      state: {
-        minWidth: 7,
-      },
-      stateString: {
-        header: 'State String',
-        minWidth: 7,
-      },
-      startLevel: {
-        header: 'Start Level',
-        minWidth: 7,
-      },
-    },
-    { printLine: (s) => cli.log(s) }
-  );
+      { printLine: (s) => this.log(s, true) }
+    );
+  }
 }
 
 Object.assign(OsgiBundlesCommand, {

--- a/src/commands/aem/rde/inspect/osgi-bundles.js
+++ b/src/commands/aem/rde/inspect/osgi-bundles.js
@@ -120,6 +120,7 @@ Object.assign(OsgiBundlesCommand, {
     scope: commonFlags.scope,
     include: commonFlags.include,
     json: commonFlags.json,
+    quiet: commonFlags.quiet,
   },
 });
 

--- a/src/commands/aem/rde/inspect/osgi-bundles.js
+++ b/src/commands/aem/rde/inspect/osgi-bundles.js
@@ -33,7 +33,7 @@ class OsgiBundlesCommand extends BaseCommand {
         if (response.status === 200) {
           const json = await response.json();
           if (flags.json) {
-            this.log(JSON.stringify(json?.items), true);
+            this.doLog(JSON.stringify(json?.items), true);
           } else {
             this.logInTableFormat(json?.items);
           }
@@ -49,7 +49,7 @@ class OsgiBundlesCommand extends BaseCommand {
         if (response.status === 200) {
           const osgiBundle = await response.json();
           if (flags.json) {
-            this.log(JSON.stringify(osgiBundle, null, 2), true);
+            this.doLog(JSON.stringify(osgiBundle, null, 2), true);
           } else {
             this.logInTableFormat([osgiBundle]);
           }
@@ -98,7 +98,7 @@ class OsgiBundlesCommand extends BaseCommand {
           minWidth: 7,
         },
       },
-      { printLine: (s) => this.log(s, true) }
+      { printLine: (s) => this.doLog(s, true) }
     );
   }
 }

--- a/src/commands/aem/rde/inspect/osgi-components.js
+++ b/src/commands/aem/rde/inspect/osgi-components.js
@@ -115,6 +115,7 @@ Object.assign(OsgiComponentsCommand, {
     scope: commonFlags.scope,
     include: commonFlags.include,
     json: commonFlags.json,
+    quiet: commonFlags.quiet,
   },
 });
 

--- a/src/commands/aem/rde/inspect/osgi-components.js
+++ b/src/commands/aem/rde/inspect/osgi-components.js
@@ -33,9 +33,9 @@ class OsgiComponentsCommand extends BaseCommand {
         if (response.status === 200) {
           const json = await response.json();
           if (flags.json) {
-            cli.log(JSON.stringify(json?.items));
+            this.log(JSON.stringify(json?.items), true);
           } else {
-            logInTableFormat(json?.items);
+            this.logInTableFormat(json?.items);
           }
         } else {
           throw new internalCodes.UNEXPECTED_API_ERROR({
@@ -49,9 +49,9 @@ class OsgiComponentsCommand extends BaseCommand {
         if (response.status === 200) {
           const osgiComponent = await response.json();
           if (flags.json) {
-            cli.log(JSON.stringify(osgiComponent, null, 2));
+            this.log(JSON.stringify(osgiComponent, null, 2), true);
           } else {
-            logInTableFormat([osgiComponent]);
+            this.logInTableFormat([osgiComponent]);
           }
         } else {
           throw new internalCodes.UNEXPECTED_API_ERROR({
@@ -68,34 +68,34 @@ class OsgiComponentsCommand extends BaseCommand {
       );
     }
   }
-}
 
-/**
- * @param {object} items - The items selectively displayed in the table.
- */
-function logInTableFormat(items) {
-  cli.table(
-    items,
-    {
-      name: {
-        header: 'NAME',
-        minWidth: 25,
+  /**
+   * @param {object} items - The items selectively displayed in the table.
+   */
+  logInTableFormat(items) {
+    cli.table(
+      items,
+      {
+        name: {
+          header: 'NAME',
+          minWidth: 25,
+        },
+        bundleId: {
+          header: 'Bundle ID',
+        },
+        scope: {
+          minWidth: 7,
+        },
+        immediate: {
+          minWidth: 7,
+        },
+        implementationClass: {
+          header: 'Implementation Class',
+        },
       },
-      bundleId: {
-        header: 'Bundle ID',
-      },
-      scope: {
-        minWidth: 7,
-      },
-      immediate: {
-        minWidth: 7,
-      },
-      implementationClass: {
-        header: 'Implementation Class',
-      },
-    },
-    { printLine: (s) => cli.log(s) }
-  );
+      { printLine: (s) => this.log(s, true) }
+    );
+  }
 }
 
 Object.assign(OsgiComponentsCommand, {

--- a/src/commands/aem/rde/inspect/osgi-components.js
+++ b/src/commands/aem/rde/inspect/osgi-components.js
@@ -33,7 +33,7 @@ class OsgiComponentsCommand extends BaseCommand {
         if (response.status === 200) {
           const json = await response.json();
           if (flags.json) {
-            this.log(JSON.stringify(json?.items), true);
+            this.doLog(JSON.stringify(json?.items), true);
           } else {
             this.logInTableFormat(json?.items);
           }
@@ -49,7 +49,7 @@ class OsgiComponentsCommand extends BaseCommand {
         if (response.status === 200) {
           const osgiComponent = await response.json();
           if (flags.json) {
-            this.log(JSON.stringify(osgiComponent, null, 2), true);
+            this.doLog(JSON.stringify(osgiComponent, null, 2), true);
           } else {
             this.logInTableFormat([osgiComponent]);
           }
@@ -93,7 +93,7 @@ class OsgiComponentsCommand extends BaseCommand {
           header: 'Implementation Class',
         },
       },
-      { printLine: (s) => this.log(s, true) }
+      { printLine: (s) => this.doLog(s, true) }
     );
   }
 }

--- a/src/commands/aem/rde/inspect/osgi-configurations.js
+++ b/src/commands/aem/rde/inspect/osgi-configurations.js
@@ -33,7 +33,7 @@ class OsgiConfigurationsCommand extends BaseCommand {
         if (response.status === 200) {
           const json = await response.json();
           if (flags.json) {
-            this.log(JSON.stringify(json?.items), true);
+            this.doLog(JSON.stringify(json?.items), true);
           } else {
             this.logInTableFormat(json?.items);
           }
@@ -49,7 +49,7 @@ class OsgiConfigurationsCommand extends BaseCommand {
         if (response.status === 200) {
           const osgiConfiguration = await response.json();
           if (flags.json) {
-            this.log(JSON.stringify(osgiConfiguration, null, 2), true);
+            this.doLog(JSON.stringify(osgiConfiguration, null, 2), true);
           } else {
             this.logInTableFormat([osgiConfiguration]);
           }
@@ -80,7 +80,7 @@ class OsgiConfigurationsCommand extends BaseCommand {
           header: 'PID',
         },
       },
-      { printLine: (s) => this.log(s, true) }
+      { printLine: (s) => this.doLog(s, true) }
     );
   }
 }

--- a/src/commands/aem/rde/inspect/osgi-configurations.js
+++ b/src/commands/aem/rde/inspect/osgi-configurations.js
@@ -102,6 +102,7 @@ Object.assign(OsgiConfigurationsCommand, {
     scope: commonFlags.scope,
     include: commonFlags.include,
     json: commonFlags.json,
+    quiet: commonFlags.quiet,
   },
 });
 

--- a/src/commands/aem/rde/inspect/osgi-configurations.js
+++ b/src/commands/aem/rde/inspect/osgi-configurations.js
@@ -33,9 +33,9 @@ class OsgiConfigurationsCommand extends BaseCommand {
         if (response.status === 200) {
           const json = await response.json();
           if (flags.json) {
-            cli.log(JSON.stringify(json?.items));
+            this.log(JSON.stringify(json?.items), true);
           } else {
-            logInTableFormat(json?.items);
+            this.logInTableFormat(json?.items);
           }
         } else {
           throw new internalCodes.UNEXPECTED_API_ERROR({
@@ -49,9 +49,9 @@ class OsgiConfigurationsCommand extends BaseCommand {
         if (response.status === 200) {
           const osgiConfiguration = await response.json();
           if (flags.json) {
-            cli.log(JSON.stringify(osgiConfiguration, null, 2));
+            this.log(JSON.stringify(osgiConfiguration, null, 2), true);
           } else {
-            logInTableFormat([osgiConfiguration]);
+            this.logInTableFormat([osgiConfiguration]);
           }
         } else {
           throw new internalCodes.UNEXPECTED_API_ERROR({
@@ -68,21 +68,21 @@ class OsgiConfigurationsCommand extends BaseCommand {
       );
     }
   }
-}
 
-/**
- * @param {object} items - The items selectively displayed in the table.
- */
-function logInTableFormat(items) {
-  cli.table(
-    items,
-    {
-      pid: {
-        header: 'PID',
+  /**
+   * @param {object} items - The items selectively displayed in the table.
+   */
+  logInTableFormat(items) {
+    cli.table(
+      items,
+      {
+        pid: {
+          header: 'PID',
+        },
       },
-    },
-    { printLine: (s) => cli.log(s) }
-  );
+      { printLine: (s) => this.log(s, true) }
+    );
+  }
 }
 
 Object.assign(OsgiConfigurationsCommand, {

--- a/src/commands/aem/rde/inspect/osgi-services.js
+++ b/src/commands/aem/rde/inspect/osgi-services.js
@@ -113,6 +113,7 @@ Object.assign(OsgiServicesCommand, {
     scope: commonFlags.scope,
     include: commonFlags.include,
     json: commonFlags.json,
+    quiet: commonFlags.quiet,
   },
 });
 

--- a/src/commands/aem/rde/inspect/osgi-services.js
+++ b/src/commands/aem/rde/inspect/osgi-services.js
@@ -33,9 +33,9 @@ class OsgiServicesCommand extends BaseCommand {
         if (response.status === 200) {
           const json = await response.json();
           if (flags.json) {
-            cli.log(JSON.stringify(json.items));
+            this.log(JSON.stringify(json.items), true);
           } else {
-            logInTableFormat(json?.items);
+            this.logInTableFormat(json?.items);
           }
         } else {
           throw new internalCodes.UNEXPECTED_API_ERROR({
@@ -50,9 +50,9 @@ class OsgiServicesCommand extends BaseCommand {
         if (response.status === 200) {
           const osgiService = await response.json();
           if (flags.json) {
-            cli.log(JSON.stringify(osgiService, null, 2));
+            this.log(JSON.stringify(osgiService, null, 2), true);
           } else {
-            logInTableFormat([osgiService]);
+            this.logInTableFormat([osgiService]);
           }
         } else {
           throw new internalCodes.UNEXPECTED_API_ERROR({
@@ -69,31 +69,31 @@ class OsgiServicesCommand extends BaseCommand {
       );
     }
   }
-}
 
-/**
- * @param {object} items - The items selectively displayed in the table.
- */
-function logInTableFormat(items) {
-  cli.table(
-    items,
-    {
-      id: {
-        header: 'ID',
+  /**
+   * @param {object} items - The items selectively displayed in the table.
+   */
+  logInTableFormat(items) {
+    cli.table(
+      items,
+      {
+        id: {
+          header: 'ID',
+        },
+        scope: {
+          minWidth: 7,
+        },
+        bundleId: {
+          header: 'Bundle ID',
+          minWidth: 7,
+        },
+        types: {
+          minWidth: 7,
+        },
       },
-      scope: {
-        minWidth: 7,
-      },
-      bundleId: {
-        header: 'Bundle ID',
-        minWidth: 7,
-      },
-      types: {
-        minWidth: 7,
-      },
-    },
-    { printLine: (s) => cli.log(s) }
-  );
+      { printLine: (s) => this.log(s, true) }
+    );
+  }
 }
 
 Object.assign(OsgiServicesCommand, {

--- a/src/commands/aem/rde/inspect/osgi-services.js
+++ b/src/commands/aem/rde/inspect/osgi-services.js
@@ -33,7 +33,7 @@ class OsgiServicesCommand extends BaseCommand {
         if (response.status === 200) {
           const json = await response.json();
           if (flags.json) {
-            this.log(JSON.stringify(json.items), true);
+            this.doLog(JSON.stringify(json.items), true);
           } else {
             this.logInTableFormat(json?.items);
           }
@@ -50,7 +50,7 @@ class OsgiServicesCommand extends BaseCommand {
         if (response.status === 200) {
           const osgiService = await response.json();
           if (flags.json) {
-            this.log(JSON.stringify(osgiService, null, 2), true);
+            this.doLog(JSON.stringify(osgiService, null, 2), true);
           } else {
             this.logInTableFormat([osgiService]);
           }
@@ -91,7 +91,7 @@ class OsgiServicesCommand extends BaseCommand {
           minWidth: 7,
         },
       },
-      { printLine: (s) => this.log(s, true) }
+      { printLine: (s) => this.doLog(s, true) }
     );
   }
 }

--- a/src/commands/aem/rde/inspect/request-logs/disable.js
+++ b/src/commands/aem/rde/inspect/request-logs/disable.js
@@ -22,7 +22,7 @@ class DisableRequestLogsCommand extends BaseCommand {
         cloudSdkAPI.disableRequestLogs(flags.target)
       );
       if (response.status === 200) {
-        this.log('Request-logs disabled.');
+        this.doLog('Request-logs disabled.');
       } else {
         throw new internalCodes.UNEXPECTED_API_ERROR({
           messageValues: [response.status, response.statusText],

--- a/src/commands/aem/rde/inspect/request-logs/disable.js
+++ b/src/commands/aem/rde/inspect/request-logs/disable.js
@@ -50,6 +50,7 @@ Object.assign(DisableRequestLogsCommand, {
     programId: commonFlags.programId,
     environmentId: commonFlags.environmentId,
     target: commonFlags.targetInspect,
+    quiet: commonFlags.quiet,
   },
 });
 

--- a/src/commands/aem/rde/inspect/request-logs/disable.js
+++ b/src/commands/aem/rde/inspect/request-logs/disable.js
@@ -11,11 +11,7 @@
  */
 'use strict';
 
-const {
-  cli,
-  BaseCommand,
-  commonFlags,
-} = require('../../../../../lib/base-command');
+const { BaseCommand, commonFlags } = require('../../../../../lib/base-command');
 const { codes: internalCodes } = require('../../../../../lib/internal-errors');
 const { throwAioError } = require('../../../../../lib/error-helpers');
 
@@ -26,7 +22,7 @@ class DisableRequestLogsCommand extends BaseCommand {
         cloudSdkAPI.disableRequestLogs(flags.target)
       );
       if (response.status === 200) {
-        cli.log('Request-logs disabled.');
+        this.log('Request-logs disabled.');
       } else {
         throw new internalCodes.UNEXPECTED_API_ERROR({
           messageValues: [response.status, response.statusText],

--- a/src/commands/aem/rde/inspect/request-logs/enable.js
+++ b/src/commands/aem/rde/inspect/request-logs/enable.js
@@ -121,6 +121,7 @@ Object.assign(EnableRequestLogsCommand, {
       multiple: true,
       required: false,
     }),
+    quiet: commonFlags.quiet,
   },
 });
 

--- a/src/commands/aem/rde/inspect/request-logs/enable.js
+++ b/src/commands/aem/rde/inspect/request-logs/enable.js
@@ -59,7 +59,7 @@ class EnableRequestLogsCommand extends BaseCommand {
       );
 
       if (response.status === 201) {
-        this.log('Request-logs enabled.');
+        this.doLog('Request-logs enabled.');
       } else {
         throw new internalCodes.UNEXPECTED_API_ERROR({
           messageValues: [response.status, response.statusText],

--- a/src/commands/aem/rde/inspect/request-logs/enable.js
+++ b/src/commands/aem/rde/inspect/request-logs/enable.js
@@ -12,7 +12,6 @@
 'use strict';
 
 const {
-  cli,
   Flags,
   BaseCommand,
   commonFlags,
@@ -60,7 +59,7 @@ class EnableRequestLogsCommand extends BaseCommand {
       );
 
       if (response.status === 201) {
-        cli.log('Request-logs enabled.');
+        this.log('Request-logs enabled.');
       } else {
         throw new internalCodes.UNEXPECTED_API_ERROR({
           messageValues: [response.status, response.statusText],

--- a/src/commands/aem/rde/inspect/request-logs/index.js
+++ b/src/commands/aem/rde/inspect/request-logs/index.js
@@ -48,7 +48,7 @@ class RequestLogsCommand extends BaseCommand {
         if (response?.status === 200) {
           const requestLog = await response.json();
           if (flags.json) {
-            this.log(JSON.stringify(requestLog, null, 2), true);
+            this.doLog(JSON.stringify(requestLog, null, 2), true);
           } else {
             this.logInTableFormat([requestLog]);
           }
@@ -86,7 +86,7 @@ class RequestLogsCommand extends BaseCommand {
           minWidth: 7,
         },
       },
-      { printLine: (s) => this.log(s, true) }
+      { printLine: (s) => this.doLog(s, true) }
     );
   }
 }

--- a/src/commands/aem/rde/inspect/request-logs/index.js
+++ b/src/commands/aem/rde/inspect/request-logs/index.js
@@ -107,6 +107,7 @@ Object.assign(RequestLogsCommand, {
     target: commonFlags.targetInspect,
     include: commonFlags.include,
     json: commonFlags.json,
+    quiet: commonFlags.quiet,
   },
 });
 

--- a/src/commands/aem/rde/inspect/request-logs/index.js
+++ b/src/commands/aem/rde/inspect/request-logs/index.js
@@ -34,7 +34,7 @@ class RequestLogsCommand extends BaseCommand {
           if (flags.json) {
             this.logInJsonArrayFormat(json?.items);
           } else {
-            logInTableFormat(json?.items);
+            this.logInTableFormat(json?.items);
           }
         } else {
           throw new internalCodes.UNEXPECTED_API_ERROR({
@@ -48,9 +48,9 @@ class RequestLogsCommand extends BaseCommand {
         if (response?.status === 200) {
           const requestLog = await response.json();
           if (flags.json) {
-            cli.log(JSON.stringify(requestLog, null, 2));
+            this.log(JSON.stringify(requestLog, null, 2), true);
           } else {
-            logInTableFormat([requestLog]);
+            this.logInTableFormat([requestLog]);
           }
         } else {
           throw new internalCodes.UNEXPECTED_API_ERROR({
@@ -67,28 +67,28 @@ class RequestLogsCommand extends BaseCommand {
       );
     }
   }
-}
 
-/**
- * @param {object} items - The items selectively displayed in the table.
- */
-function logInTableFormat(items) {
-  cli.table(
-    items,
-    {
-      id: {
-        header: 'ID',
-        minWidth: 20,
+  /**
+   * @param {object} items - The items selectively displayed in the table.
+   */
+  logInTableFormat(items) {
+    cli.table(
+      items,
+      {
+        id: {
+          header: 'ID',
+          minWidth: 20,
+        },
+        method: {
+          minWidth: 7,
+        },
+        path: {
+          minWidth: 7,
+        },
       },
-      method: {
-        minWidth: 7,
-      },
-      path: {
-        minWidth: 7,
-      },
-    },
-    { printLine: (s) => cli.log(s) }
-  );
+      { printLine: (s) => this.log(s, true) }
+    );
+  }
 }
 
 Object.assign(RequestLogsCommand, {

--- a/src/commands/aem/rde/install.js
+++ b/src/commands/aem/rde/install.js
@@ -192,7 +192,7 @@ class DeployCommand extends BaseCommand {
         }
       }
     } catch (err) {
-      this.log(err);
+      this.doLog(err);
       return;
     }
 
@@ -204,7 +204,7 @@ class DeployCommand extends BaseCommand {
           abort: () => progressBar.stop(),
           start: (size, msg) => {
             if (msg) {
-              this.log(msg);
+              this.doLog(msg);
             }
             progressBar.start(size, 0);
           },

--- a/src/commands/aem/rde/install.js
+++ b/src/commands/aem/rde/install.js
@@ -135,13 +135,13 @@ async function processInputFile(isLocalFile, type, inputPath) {
       if (!file.isDirectory()) {
         break;
       }
-      return await frontendInputBuild(cli, inputPath);
+      return await frontendInputBuild(this, inputPath);
     }
     case 'dispatcher-config': {
       if (!file.isDirectory()) {
         break;
       }
-      return await dispatcherInputBuild(cli, inputPath);
+      return await dispatcherInputBuild(this, inputPath);
     }
     default: {
       if (file.isDirectory()) {
@@ -234,7 +234,7 @@ class DeployCommand extends BaseCommand {
       }).finally(() => this.spinnerStop());
 
       await this.withCloudSdk((cloudSdkAPI) =>
-        loadUpdateHistory(cloudSdkAPI, change.updateId, cli, (done, text) =>
+        loadUpdateHistory(cloudSdkAPI, change.updateId, this, (done, text) =>
           done ? this.spinnerStop() : this.spinnerStart(text)
         )
       );

--- a/src/commands/aem/rde/install.js
+++ b/src/commands/aem/rde/install.js
@@ -192,7 +192,7 @@ class DeployCommand extends BaseCommand {
         }
       }
     } catch (err) {
-      cli.log(err);
+      this.log(err);
       return;
     }
 
@@ -204,7 +204,7 @@ class DeployCommand extends BaseCommand {
           abort: () => progressBar.stop(),
           start: (size, msg) => {
             if (msg) {
-              cli.log(msg);
+              this.log(msg);
             }
             progressBar.start(size, 0);
           },

--- a/src/commands/aem/rde/logs.js
+++ b/src/commands/aem/rde/logs.js
@@ -11,7 +11,7 @@
  */
 'use strict';
 
-const { cli, Flags } = require('../../../lib/base-command');
+const { Flags } = require('../../../lib/base-command');
 const { codes: internalCodes } = require('../../../lib/internal-errors');
 const { throwAioError } = require('../../../lib/error-helpers');
 const { BaseCommand, commonFlags } = require('../../../lib/base-command');
@@ -255,7 +255,7 @@ class LogsCommand extends BaseCommand {
       );
       for (let i = 0; i < logLines.length && !this.stopped; i++) {
         const line = colorize ? this.colorizeLine(logLines[i]) : logLines[i];
-        cli.log(line);
+        this.log(line, true);
         await sleepMillis(perLineDelay);
       }
     } else if (response.status === 404) {

--- a/src/commands/aem/rde/logs.js
+++ b/src/commands/aem/rde/logs.js
@@ -340,6 +340,7 @@ Object.assign(LogsCommand, {
       multiple: true,
       required: false,
     }),
+    quiet: commonFlags.quiet,
   },
 });
 

--- a/src/commands/aem/rde/logs.js
+++ b/src/commands/aem/rde/logs.js
@@ -61,7 +61,7 @@ class LogsCommand extends BaseCommand {
           }
         }, REQUEST_INTERVAL_MS);
       } else {
-        this.log('No active log configuration found.');
+        this.doLog('No active log configuration found.');
       }
     } catch (err) {
       await this.stopAndCleanup();
@@ -169,7 +169,7 @@ class LogsCommand extends BaseCommand {
           messageValues: [response.status, response.statusText],
         });
       }
-      this.log('\nLog configuration removed.');
+      this.doLog('\nLog configuration removed.');
     } catch (err) {
       throw new internalCodes.INTERNAL_DELETE_LOG_ERROR({ messageValues: err });
     }
@@ -255,11 +255,11 @@ class LogsCommand extends BaseCommand {
       );
       for (let i = 0; i < logLines.length && !this.stopped; i++) {
         const line = colorize ? this.colorizeLine(logLines[i]) : logLines[i];
-        this.log(line, true);
+        this.doLog(line, true);
         await sleepMillis(perLineDelay);
       }
     } else if (response.status === 404) {
-      this.log(
+      this.doLog(
         'Log configuration not found any longer. It may has been removed by introducing another new log configuration.'
       );
       await this.stopAndCleanup();

--- a/src/commands/aem/rde/logs.js
+++ b/src/commands/aem/rde/logs.js
@@ -61,7 +61,7 @@ class LogsCommand extends BaseCommand {
           }
         }, REQUEST_INTERVAL_MS);
       } else {
-        cli.log('No active log configuration found.');
+        this.log('No active log configuration found.');
       }
     } catch (err) {
       await this.stopAndCleanup();
@@ -169,7 +169,7 @@ class LogsCommand extends BaseCommand {
           messageValues: [response.status, response.statusText],
         });
       }
-      cli.log('\nLog configuration removed.');
+      this.log('\nLog configuration removed.');
     } catch (err) {
       throw new internalCodes.INTERNAL_DELETE_LOG_ERROR({ messageValues: err });
     }
@@ -259,7 +259,7 @@ class LogsCommand extends BaseCommand {
         await sleepMillis(perLineDelay);
       }
     } else if (response.status === 404) {
-      cli.log(
+      this.log(
         'Log configuration not found any longer. It may has been removed by introducing another new log configuration.'
       );
       await this.stopAndCleanup();

--- a/src/commands/aem/rde/reset.js
+++ b/src/commands/aem/rde/reset.js
@@ -22,16 +22,16 @@ const { throwAioError } = require('../../../lib/error-helpers');
 class ResetCommand extends BaseCommand {
   async runCommand(args, flags) {
     try {
-      this.log(`Reset cm-p${this._programId}-e${this._environmentId}`);
+      this.doLog(`Reset cm-p${this._programId}-e${this._environmentId}`);
       this.spinnerStart('resetting environment');
       await this.withCloudSdk((cloudSdkAPI) =>
         cloudSdkAPI.resetEnv(flags.wait)
       );
       this.spinnerStop();
       if (flags.wait) {
-        this.log(`Environment reset.`);
+        this.doLog(`Environment reset.`);
       } else {
-        this.log(
+        this.doLog(
           `Not waiting to finish reset. Check using status command for progress. It may take a couple of seconds to indicate 'Deployment in progress'.`
         );
       }

--- a/src/commands/aem/rde/reset.js
+++ b/src/commands/aem/rde/reset.js
@@ -19,17 +19,16 @@ const {
 } = require('../../../lib/base-command');
 const { codes: internalCodes } = require('../../../lib/internal-errors');
 const { throwAioError } = require('../../../lib/error-helpers');
-const spinner = require('ora')();
 
 class ResetCommand extends BaseCommand {
   async runCommand(args, flags) {
     try {
       cli.log(`Reset cm-p${this._programId}-e${this._environmentId}`);
-      spinner.start('resetting environment');
+      this.spinnerStart('resetting environment');
       await this.withCloudSdk((cloudSdkAPI) =>
         cloudSdkAPI.resetEnv(flags.wait)
       );
-      spinner.stop();
+      this.spinnerStop();
       if (flags.wait) {
         cli.log(`Environment reset.`);
       } else {
@@ -38,7 +37,7 @@ class ResetCommand extends BaseCommand {
         );
       }
     } catch (err) {
-      spinner.stop();
+      this.spinnerStop();
       throwAioError(
         err,
         new internalCodes.INTERNAL_RESET_ERROR({ messageValues: err })
@@ -62,6 +61,7 @@ Object.assign(ResetCommand, {
       default: true,
       allowNo: true,
     }),
+    quiet: commonFlags.quiet,
   },
   aliases: [],
 });

--- a/src/commands/aem/rde/reset.js
+++ b/src/commands/aem/rde/reset.js
@@ -13,7 +13,6 @@
 
 const {
   BaseCommand,
-  cli,
   Flags,
   commonFlags,
 } = require('../../../lib/base-command');
@@ -23,16 +22,16 @@ const { throwAioError } = require('../../../lib/error-helpers');
 class ResetCommand extends BaseCommand {
   async runCommand(args, flags) {
     try {
-      cli.log(`Reset cm-p${this._programId}-e${this._environmentId}`);
+      this.log(`Reset cm-p${this._programId}-e${this._environmentId}`);
       this.spinnerStart('resetting environment');
       await this.withCloudSdk((cloudSdkAPI) =>
         cloudSdkAPI.resetEnv(flags.wait)
       );
       this.spinnerStop();
       if (flags.wait) {
-        cli.log(`Environment reset.`);
+        this.log(`Environment reset.`);
       } else {
-        cli.log(
+        this.log(
           `Not waiting to finish reset. Check using status command for progress. It may take a couple of seconds to indicate 'Deployment in progress'.`
         );
       }

--- a/src/commands/aem/rde/restart.js
+++ b/src/commands/aem/rde/restart.js
@@ -18,11 +18,11 @@ const { throwAioError } = require('../../../lib/error-helpers');
 class RestartCommand extends BaseCommand {
   async runCommand(args, flags) {
     try {
-      this.log(`Restart cm-p${this._programId}-e${this._environmentId}`);
+      this.doLog(`Restart cm-p${this._programId}-e${this._environmentId}`);
       this.spinnerStart('restarting environment');
       await this.withCloudSdk((cloudSdkAPI) => cloudSdkAPI.restartEnv());
       this.spinnerStop();
-      this.log(`Environment restarted.`);
+      this.doLog(`Environment restarted.`);
     } catch (err) {
       this.spinnerStop();
       throwAioError(

--- a/src/commands/aem/rde/restart.js
+++ b/src/commands/aem/rde/restart.js
@@ -14,18 +14,17 @@
 const { BaseCommand, cli, commonFlags } = require('../../../lib/base-command');
 const { codes: internalCodes } = require('../../../lib/internal-errors');
 const { throwAioError } = require('../../../lib/error-helpers');
-const spinner = require('ora')();
 
 class RestartCommand extends BaseCommand {
   async runCommand(args, flags) {
     try {
       cli.log(`Restart cm-p${this._programId}-e${this._environmentId}`);
-      spinner.start('restarting environment');
+      this.spinnerStart('restarting environment');
       await this.withCloudSdk((cloudSdkAPI) => cloudSdkAPI.restartEnv());
-      spinner.stop();
+      this.spinnerStop();
       cli.log(`Environment restarted.`);
     } catch (err) {
-      spinner.stop();
+      this.spinnerStop();
       throwAioError(
         err,
         new internalCodes.INTERNAL_RESTART_ERROR({ messageValues: err })
@@ -42,6 +41,7 @@ Object.assign(RestartCommand, {
     organizationId: commonFlags.organizationId,
     programId: commonFlags.programId,
     environmentId: commonFlags.environmentId,
+    quiet: commonFlags.quiet,
   },
 });
 

--- a/src/commands/aem/rde/restart.js
+++ b/src/commands/aem/rde/restart.js
@@ -11,18 +11,18 @@
  */
 'use strict';
 
-const { BaseCommand, cli, commonFlags } = require('../../../lib/base-command');
+const { BaseCommand, commonFlags } = require('../../../lib/base-command');
 const { codes: internalCodes } = require('../../../lib/internal-errors');
 const { throwAioError } = require('../../../lib/error-helpers');
 
 class RestartCommand extends BaseCommand {
   async runCommand(args, flags) {
     try {
-      cli.log(`Restart cm-p${this._programId}-e${this._environmentId}`);
+      this.log(`Restart cm-p${this._programId}-e${this._environmentId}`);
       this.spinnerStart('restarting environment');
       await this.withCloudSdk((cloudSdkAPI) => cloudSdkAPI.restartEnv());
       this.spinnerStop();
-      cli.log(`Environment restarted.`);
+      this.log(`Environment restarted.`);
     } catch (err) {
       this.spinnerStop();
       throwAioError(

--- a/src/commands/aem/rde/setup.js
+++ b/src/commands/aem/rde/setup.js
@@ -372,17 +372,17 @@ class SetupCommand extends BaseCommand {
     selectedEnvironment
   ) {
     if (prevOrg && prevOrg !== orgId) {
-      cli.info(chalk.gray(`Your previous organization ID was: ${prevOrg}`));
+      this.log(chalk.gray(`Your previous organization ID was: ${prevOrg}`));
     }
     if (prevProgram && prevProgram !== selectedProgram) {
-      cli.info(
+      this.log(
         chalk.gray(
           `Your previous program ID was: ${prevProgram} (name: ${prevProgramName})`
         )
       );
     }
     if (prevEnv && prevEnv !== selectedEnvironment) {
-      cli.info(
+      this.log(
         chalk.gray(
           `Your previous environment ID was: ${prevEnv} (name: ${prevEnvName})`
         )

--- a/src/commands/aem/rde/setup.js
+++ b/src/commands/aem/rde/setup.js
@@ -22,7 +22,6 @@ const inquirer = require('inquirer');
 const chalk = require('chalk');
 const open = require('open');
 const { concatEnvironemntId } = require('../../../lib/utils');
-const spinner = require('ora')();
 
 /**
  * The `SetupCommand` class extends the `BaseCommand` class and is used to handle setup related commands.
@@ -162,11 +161,11 @@ class SetupCommand extends BaseCommand {
 
   async getProgramId() {
     if (!programsCached) {
-      spinner.start('retrieving programs of your organization');
+      this.spinnerStart('retrieving programs of your organization');
       programsCached = await this.withCloudSdkBase((cloudSdkAPI) =>
         cloudSdkAPI.listProgramsIdAndName()
       );
-      spinner.stop();
+      this.spinnerStop();
 
       if (!programsCached || programsCached.length === 0) {
         cli.log(chalk.red('No programs found for the selected organization.'));
@@ -205,11 +204,11 @@ class SetupCommand extends BaseCommand {
   }
 
   async getEnvironmentId(selectedProgram) {
-    spinner.start(`retrieving environments of program ${selectedProgram}`);
+    this.spinnerStart(`retrieving environments of program ${selectedProgram}`);
     environmentsCached = await this.withCloudSdkBase((cloudSdkAPI) =>
       cloudSdkAPI.listEnvironmentsIdAndName(selectedProgram)
     );
-    spinner.stop();
+    this.spinnerStop();
 
     // FIXME this filter must be removed as soon as other types are supported
     environmentsCached = environmentsCached.filter((env) => env.type === 'rde');
@@ -342,7 +341,7 @@ class SetupCommand extends BaseCommand {
         `Setup complete. Use 'aio help aem rde' to see the available commands.`
       );
     } catch (err) {
-      spinner.stop();
+      this.spinnerStop();
       throwAioError(
         err,
         new internalCodes.UNEXPECTED_API_ERROR({ messageValues: err })

--- a/src/commands/aem/rde/setup.js
+++ b/src/commands/aem/rde/setup.js
@@ -84,7 +84,7 @@ class SetupCommand extends BaseCommand {
       return orgMap;
     } catch (err) {
       if (err.code === 'CONTEXT_NOT_CONFIGURED') {
-        this.log('No IMS context found. Please run `aio login` first.');
+        this.doLog('No IMS context found. Please run `aio login` first.');
       }
       return null;
     }
@@ -103,12 +103,12 @@ class SetupCommand extends BaseCommand {
     } else if (nrOfOrganizations === 1) {
       const orgName = Object.keys(organizations)[0];
       const orgId = organizations[orgName];
-      this.log(`Selected only organization: ${orgName} - ${orgId}`);
+      this.doLog(`Selected only organization: ${orgName} - ${orgId}`);
       return orgId;
     } else {
       selectedOrg = await this.chooseOrganizationFromList(organizations);
     }
-    this.log(`Selected organization: ${selectedOrg}`);
+    this.doLog(`Selected organization: ${selectedOrg}`);
     return selectedOrg;
   }
 
@@ -135,9 +135,9 @@ class SetupCommand extends BaseCommand {
   }
 
   async fallbackToManualOrganizationId() {
-    this.log(chalk.yellow('Could not find an organization ID automatically.'));
-    this.log(chalk.yellow('Please enter your organization ID manually.'));
-    this.log(chalk.gray(`See ${LINK_ORGID}`));
+    this.doLog(chalk.yellow('Could not find an organization ID automatically.'));
+    this.doLog(chalk.yellow('Please enter your organization ID manually.'));
+    this.doLog(chalk.gray(`See ${LINK_ORGID}`));
     const openLink = await inquirer.prompt([
       {
         type: 'confirm',
@@ -168,13 +168,13 @@ class SetupCommand extends BaseCommand {
       this.spinnerStop();
 
       if (!programsCached || programsCached.length === 0) {
-        this.log(chalk.red('No programs found for the selected organization.'));
+        this.doLog(chalk.red('No programs found for the selected organization.'));
         return null;
       }
     }
 
     if (programsCached.length === 1) {
-      this.log(`Selected only program: ${programsCached[0].id}`);
+      this.doLog(`Selected only program: ${programsCached[0].id}`);
       return programsCached[0].id;
     }
 
@@ -214,15 +214,15 @@ class SetupCommand extends BaseCommand {
     environmentsCached = environmentsCached.filter((env) => env.type === 'rde');
 
     if (environmentsCached.length === 0) {
-      this.log(
+      this.doLog(
         chalk.red(`No environments found for program ${selectedProgram}`)
       );
-      this.log('==> Please choose a different program');
+      this.doLog('==> Please choose a different program');
       return null;
     }
 
     if (environmentsCached.length === 1) {
-      this.log(`Selected only environment: ${environmentsCached[0].id}`);
+      this.doLog(`Selected only environment: ${environmentsCached[0].id}`);
       return environmentsCached[0].id;
     }
 
@@ -258,7 +258,7 @@ class SetupCommand extends BaseCommand {
         require('inquirer-autocomplete-prompt')
       );
 
-      this.log(`Setup the CLI configuration necessary to use the RDE commands.`);
+      this.doLog(`Setup the CLI configuration necessary to use the RDE commands.`);
 
       const storeLocal = await inquirer.prompt([
         {
@@ -284,7 +284,7 @@ class SetupCommand extends BaseCommand {
 
         selectedEnvironmentId = await this.getEnvironmentId(selectedProgramId);
         if (selectedEnvironmentId === null && programsCached?.length === 1) {
-          this.log(
+          this.doLog(
             chalk.red(
               'No program or environment found for the selected organization.'
             )
@@ -300,7 +300,7 @@ class SetupCommand extends BaseCommand {
         (e) => e.id === selectedProgramId
       ).name;
 
-      this.log(
+      this.doLog(
         chalk.green(
           `Selected ${concatEnvironemntId(selectedProgramId, selectedEnvironmentId)}: ${selectedProgramName} - ${selectedEnvironmentName}`
         )
@@ -337,7 +337,7 @@ class SetupCommand extends BaseCommand {
         selectedEnvironmentId
       );
 
-      this.log(
+      this.doLog(
         `Setup complete. Use 'aio help aem rde' to see the available commands.`
       );
     } catch (err) {
@@ -372,17 +372,17 @@ class SetupCommand extends BaseCommand {
     selectedEnvironment
   ) {
     if (prevOrg && prevOrg !== orgId) {
-      this.log(chalk.gray(`Your previous organization ID was: ${prevOrg}`));
+      this.doLog(chalk.gray(`Your previous organization ID was: ${prevOrg}`));
     }
     if (prevProgram && prevProgram !== selectedProgram) {
-      this.log(
+      this.doLog(
         chalk.gray(
           `Your previous program ID was: ${prevProgram} (name: ${prevProgramName})`
         )
       );
     }
     if (prevEnv && prevEnv !== selectedEnvironment) {
-      this.log(
+      this.doLog(
         chalk.gray(
           `Your previous environment ID was: ${prevEnv} (name: ${prevEnvName})`
         )

--- a/src/commands/aem/rde/setup.js
+++ b/src/commands/aem/rde/setup.js
@@ -84,7 +84,7 @@ class SetupCommand extends BaseCommand {
       return orgMap;
     } catch (err) {
       if (err.code === 'CONTEXT_NOT_CONFIGURED') {
-        cli.log('No IMS context found. Please run `aio login` first.');
+        this.log('No IMS context found. Please run `aio login` first.');
       }
       return null;
     }
@@ -103,12 +103,12 @@ class SetupCommand extends BaseCommand {
     } else if (nrOfOrganizations === 1) {
       const orgName = Object.keys(organizations)[0];
       const orgId = organizations[orgName];
-      cli.log(`Selected only organization: ${orgName} - ${orgId}`);
+      this.log(`Selected only organization: ${orgName} - ${orgId}`);
       return orgId;
     } else {
       selectedOrg = await this.chooseOrganizationFromList(organizations);
     }
-    cli.log(`Selected organization: ${selectedOrg}`);
+    this.log(`Selected organization: ${selectedOrg}`);
     return selectedOrg;
   }
 
@@ -135,9 +135,9 @@ class SetupCommand extends BaseCommand {
   }
 
   async fallbackToManualOrganizationId() {
-    cli.log(chalk.yellow('Could not find an organization ID automatically.'));
-    cli.log(chalk.yellow('Please enter your organization ID manually.'));
-    cli.log(chalk.gray(`See ${LINK_ORGID}`));
+    this.log(chalk.yellow('Could not find an organization ID automatically.'));
+    this.log(chalk.yellow('Please enter your organization ID manually.'));
+    this.log(chalk.gray(`See ${LINK_ORGID}`));
     const openLink = await inquirer.prompt([
       {
         type: 'confirm',
@@ -168,13 +168,13 @@ class SetupCommand extends BaseCommand {
       this.spinnerStop();
 
       if (!programsCached || programsCached.length === 0) {
-        cli.log(chalk.red('No programs found for the selected organization.'));
+        this.log(chalk.red('No programs found for the selected organization.'));
         return null;
       }
     }
 
     if (programsCached.length === 1) {
-      cli.log(`Selected only program: ${programsCached[0].id}`);
+      this.log(`Selected only program: ${programsCached[0].id}`);
       return programsCached[0].id;
     }
 
@@ -214,15 +214,15 @@ class SetupCommand extends BaseCommand {
     environmentsCached = environmentsCached.filter((env) => env.type === 'rde');
 
     if (environmentsCached.length === 0) {
-      cli.log(
+      this.log(
         chalk.red(`No environments found for program ${selectedProgram}`)
       );
-      cli.log('==> Please choose a different program');
+      this.log('==> Please choose a different program');
       return null;
     }
 
     if (environmentsCached.length === 1) {
-      cli.log(`Selected only environment: ${environmentsCached[0].id}`);
+      this.log(`Selected only environment: ${environmentsCached[0].id}`);
       return environmentsCached[0].id;
     }
 
@@ -258,7 +258,7 @@ class SetupCommand extends BaseCommand {
         require('inquirer-autocomplete-prompt')
       );
 
-      cli.log(`Setup the CLI configuration necessary to use the RDE commands.`);
+      this.log(`Setup the CLI configuration necessary to use the RDE commands.`);
 
       const storeLocal = await inquirer.prompt([
         {
@@ -284,7 +284,7 @@ class SetupCommand extends BaseCommand {
 
         selectedEnvironmentId = await this.getEnvironmentId(selectedProgramId);
         if (selectedEnvironmentId === null && programsCached?.length === 1) {
-          cli.log(
+          this.log(
             chalk.red(
               'No program or environment found for the selected organization.'
             )
@@ -300,7 +300,7 @@ class SetupCommand extends BaseCommand {
         (e) => e.id === selectedProgramId
       ).name;
 
-      cli.log(
+      this.log(
         chalk.green(
           `Selected ${concatEnvironemntId(selectedProgramId, selectedEnvironmentId)}: ${selectedProgramName} - ${selectedEnvironmentName}`
         )
@@ -337,7 +337,7 @@ class SetupCommand extends BaseCommand {
         selectedEnvironmentId
       );
 
-      cli.log(
+      this.log(
         `Setup complete. Use 'aio help aem rde' to see the available commands.`
       );
     } catch (err) {

--- a/src/commands/aem/rde/setup.js
+++ b/src/commands/aem/rde/setup.js
@@ -11,7 +11,7 @@
  */
 'use strict';
 
-const { BaseCommand, cli } = require('../../../lib/base-command');
+const { BaseCommand } = require('../../../lib/base-command');
 const { CloudSdkAPIBase } = require('../../../lib/cloud-sdk-api-base');
 const { codes: validationCodes } = require('../../../lib/validation-errors');
 const { codes: internalCodes } = require('../../../lib/internal-errors');
@@ -135,7 +135,9 @@ class SetupCommand extends BaseCommand {
   }
 
   async fallbackToManualOrganizationId() {
-    this.doLog(chalk.yellow('Could not find an organization ID automatically.'));
+    this.doLog(
+      chalk.yellow('Could not find an organization ID automatically.')
+    );
     this.doLog(chalk.yellow('Please enter your organization ID manually.'));
     this.doLog(chalk.gray(`See ${LINK_ORGID}`));
     const openLink = await inquirer.prompt([
@@ -168,7 +170,9 @@ class SetupCommand extends BaseCommand {
       this.spinnerStop();
 
       if (!programsCached || programsCached.length === 0) {
-        this.doLog(chalk.red('No programs found for the selected organization.'));
+        this.doLog(
+          chalk.red('No programs found for the selected organization.')
+        );
         return null;
       }
     }
@@ -258,7 +262,9 @@ class SetupCommand extends BaseCommand {
         require('inquirer-autocomplete-prompt')
       );
 
-      this.doLog(`Setup the CLI configuration necessary to use the RDE commands.`);
+      this.doLog(
+        `Setup the CLI configuration necessary to use the RDE commands.`
+      );
 
       const storeLocal = await inquirer.prompt([
         {

--- a/src/commands/aem/rde/status.js
+++ b/src/commands/aem/rde/status.js
@@ -102,7 +102,7 @@ class StatusCommand extends BaseCommand {
       this.log(JSON.stringify(result), true);
     } catch (err) {
       this.spinnerStop();
-      this.log(err, true);
+      this.log(err);
     }
   }
 }

--- a/src/commands/aem/rde/status.js
+++ b/src/commands/aem/rde/status.js
@@ -26,13 +26,13 @@ class StatusCommand extends BaseCommand {
 
   async printAsText() {
     try {
-      this.log(`Info for cm-p${this._programId}-e${this._environmentId}`);
+      this.doLog(`Info for cm-p${this._programId}-e${this._environmentId}`);
       this.spinnerStart('retrieving environment status information');
       const status = await this.withCloudSdk((cloudSdkAPI) =>
         loadAllArtifacts(cloudSdkAPI)
       );
       this.spinnerStop();
-      this.log(`Environment: ${status.status}`, true);
+      this.doLog(`Environment: ${status.status}`, true);
       if (status.error) {
         throw new internalCodes.UNEXPECTED_API_ERROR({
           messageValues: [status.status, status.error],
@@ -41,27 +41,27 @@ class StatusCommand extends BaseCommand {
 
       const grouped = groupArtifacts(status.items);
 
-      this.log('- Bundles Author:', true);
+      this.doLog('- Bundles Author:', true);
       grouped.author['osgi-bundle'].forEach((bundle) =>
-        this.log(
+        this.doLog(
           ` ${bundle.metadata.bundleSymbolicName}-${bundle.metadata.bundleVersion}`,
           true
         )
       );
-      this.log('- Bundles Publish:', true);
+      this.doLog('- Bundles Publish:', true);
       grouped.publish['osgi-bundle'].forEach((bundle) =>
-        this.log(
+        this.doLog(
           ` ${bundle.metadata.bundleSymbolicName}-${bundle.metadata.bundleVersion}`,
           true
         )
       );
-      this.log('- Configurations Author:', true);
+      this.doLog('- Configurations Author:', true);
       grouped.author['osgi-config'].forEach((config) =>
-        this.log(` ${config.metadata.configPid} `, true)
+        this.doLog(` ${config.metadata.configPid} `, true)
       );
-      this.log('- Configurations Publish:', true);
+      this.doLog('- Configurations Publish:', true);
       grouped.publish['osgi-config'].forEach((config) =>
-        this.log(` ${config.metadata.configPid} `, true)
+        this.doLog(` ${config.metadata.configPid} `, true)
       );
     } catch (err) {
       this.spinnerStop();
@@ -99,10 +99,10 @@ class StatusCommand extends BaseCommand {
         };
       }
 
-      this.log(JSON.stringify(result), true);
+      this.doLog(JSON.stringify(result), true);
     } catch (err) {
       this.spinnerStop();
-      this.log(err);
+      this.doLog(err);
     }
   }
 }

--- a/src/commands/aem/rde/status.js
+++ b/src/commands/aem/rde/status.js
@@ -11,7 +11,7 @@
  */
 'use strict';
 
-const { BaseCommand, cli, commonFlags } = require('../../../lib/base-command');
+const { BaseCommand, commonFlags } = require('../../../lib/base-command');
 const { loadAllArtifacts, groupArtifacts } = require('../../../lib/rde-utils');
 const { codes: internalCodes } = require('../../../lib/internal-errors');
 const { throwAioError } = require('../../../lib/error-helpers');
@@ -26,13 +26,13 @@ class StatusCommand extends BaseCommand {
 
   async printAsText() {
     try {
-      cli.log(`Info for cm-p${this._programId}-e${this._environmentId}`);
+      this.log(`Info for cm-p${this._programId}-e${this._environmentId}`);
       this.spinnerStart('retrieving environment status information');
       const status = await this.withCloudSdk((cloudSdkAPI) =>
         loadAllArtifacts(cloudSdkAPI)
       );
       this.spinnerStop();
-      cli.log(`Environment: ${status.status}`);
+      this.log(`Environment: ${status.status}`, true);
       if (status.error) {
         throw new internalCodes.UNEXPECTED_API_ERROR({
           messageValues: [status.status, status.error],
@@ -41,25 +41,27 @@ class StatusCommand extends BaseCommand {
 
       const grouped = groupArtifacts(status.items);
 
-      cli.log('- Bundles Author:');
+      this.log('- Bundles Author:', true);
       grouped.author['osgi-bundle'].forEach((bundle) =>
-        cli.log(
-          ` ${bundle.metadata.bundleSymbolicName}-${bundle.metadata.bundleVersion}`
+        this.log(
+          ` ${bundle.metadata.bundleSymbolicName}-${bundle.metadata.bundleVersion}`,
+          true
         )
       );
-      cli.log('- Bundles Publish:');
+      this.log('- Bundles Publish:', true);
       grouped.publish['osgi-bundle'].forEach((bundle) =>
-        cli.log(
-          ` ${bundle.metadata.bundleSymbolicName}-${bundle.metadata.bundleVersion}`
+        this.log(
+          ` ${bundle.metadata.bundleSymbolicName}-${bundle.metadata.bundleVersion}`,
+          true
         )
       );
-      cli.log('- Configurations Author:');
+      this.log('- Configurations Author:', true);
       grouped.author['osgi-config'].forEach((config) =>
-        cli.log(` ${config.metadata.configPid} `)
+        this.log(` ${config.metadata.configPid} `, true)
       );
-      cli.log('- Configurations Publish:');
+      this.log('- Configurations Publish:', true);
       grouped.publish['osgi-config'].forEach((config) =>
-        cli.log(` ${config.metadata.configPid} `)
+        this.log(` ${config.metadata.configPid} `, true)
       );
     } catch (err) {
       this.spinnerStop();
@@ -97,10 +99,10 @@ class StatusCommand extends BaseCommand {
         };
       }
 
-      cli.log(JSON.stringify(result));
+      this.log(JSON.stringify(result), true);
     } catch (err) {
       this.spinnerStop();
-      cli.log(err);
+      this.log(err, true);
     }
   }
 }

--- a/src/commands/aem/rde/status.js
+++ b/src/commands/aem/rde/status.js
@@ -15,7 +15,6 @@ const { BaseCommand, cli, commonFlags } = require('../../../lib/base-command');
 const { loadAllArtifacts, groupArtifacts } = require('../../../lib/rde-utils');
 const { codes: internalCodes } = require('../../../lib/internal-errors');
 const { throwAioError } = require('../../../lib/error-helpers');
-const spinner = require('ora')();
 class StatusCommand extends BaseCommand {
   async runCommand(args, flags) {
     if (flags.json) {
@@ -28,11 +27,11 @@ class StatusCommand extends BaseCommand {
   async printAsText() {
     try {
       cli.log(`Info for cm-p${this._programId}-e${this._environmentId}`);
-      spinner.start('retrieving environment status information');
+      this.spinnerStart('retrieving environment status information');
       const status = await this.withCloudSdk((cloudSdkAPI) =>
         loadAllArtifacts(cloudSdkAPI)
       );
-      spinner.stop();
+      this.spinnerStop();
       cli.log(`Environment: ${status.status}`);
       if (status.error) {
         throw new internalCodes.UNEXPECTED_API_ERROR({
@@ -63,7 +62,7 @@ class StatusCommand extends BaseCommand {
         cli.log(` ${config.metadata.configPid} `)
       );
     } catch (err) {
-      spinner.stop();
+      this.spinnerStop();
       throwAioError(
         err,
         new internalCodes.INTERNAL_STATUS_ERROR({ messageValues: err })
@@ -100,7 +99,7 @@ class StatusCommand extends BaseCommand {
 
       cli.log(JSON.stringify(result));
     } catch (err) {
-      spinner.stop();
+      this.spinnerStop();
       cli.log(err);
     }
   }
@@ -115,6 +114,7 @@ Object.assign(StatusCommand, {
     programId: commonFlags.programId,
     environmentId: commonFlags.environmentId,
     json: commonFlags.json,
+    quiet: commonFlags.quiet,
   },
   usage: [
     'status              # output as textual content',

--- a/src/lib/base-command.js
+++ b/src/lib/base-command.js
@@ -162,7 +162,7 @@ class BaseCommand extends Command {
     });
     jsonArray = jsonArray.slice(0, -2);
     jsonArray += '\n]';
-    CliUx.ux.log(jsonArray);
+    this.log(jsonArray, true);
   }
 
   /**

--- a/src/lib/base-command.js
+++ b/src/lib/base-command.js
@@ -117,6 +117,12 @@ class BaseCommand extends Command {
     return '';
   }
 
+  log(message, always = false) {
+    if (always || !this.flags.quiet) {
+      CliUx.ux.log(message);
+    }
+  }
+
   spinnerStart(message) {
     if (!this.flags.quiet) {
       spinner.start(message);

--- a/src/lib/base-command.js
+++ b/src/lib/base-command.js
@@ -49,7 +49,7 @@ class BaseCommand extends Command {
     this.setupParams(flags);
 
     if (!flags.quiet && this.constructor.name !== 'SetupCommand') {
-      CliUx.ux.log(this.getLogHeader());
+      this.doLog(this.getLogHeader());
       const lastAction = Config.get('rde_lastaction');
       if (lastAction && Date.now() - lastAction > 24 * 60 * 60 * 1000) {
         const executeCommand = await inquirer.prompt([
@@ -61,7 +61,7 @@ class BaseCommand extends Command {
           },
         ]);
         if (!executeCommand.executeCommand) {
-          CliUx.ux.log('Command execution aborted.');
+          this.doLog('Command execution aborted.');
           return;
         }
       }
@@ -117,7 +117,7 @@ class BaseCommand extends Command {
     return '';
   }
 
-  log(message, always = false) {
+  doLog(message, always = false) {
     if (always || !this.flags.quiet) {
       CliUx.ux.log(message);
     }
@@ -162,7 +162,7 @@ class BaseCommand extends Command {
     });
     jsonArray = jsonArray.slice(0, -2);
     jsonArray += '\n]';
-    this.log(jsonArray, true);
+    this.doLog(jsonArray, true);
   }
 
   /**

--- a/src/lib/dispatcher.js
+++ b/src/lib/dispatcher.js
@@ -16,22 +16,14 @@ const os = require('os');
 const path = require('path');
 const archiver = require('archiver');
 
-/**
- * @param closure
- * @param successPredicate
- * @param retryIntervalSeconds
- * @param maxRetries
- * @param cli
- * @param inputPath
- */
-async function dispatcherInputBuild(cli, inputPath) {
+async function dispatcherInputBuild(basecommand, inputPath) {
   return new Promise((resolve, reject) => {
     fs.mkdtemp(path.join(os.tmpdir(), 'aio-rde-'), (err, folder) => {
       if (err) {
         return reject(err);
       }
       const targetZipPath = path.join(folder, 'dispatcher.zip');
-      return archiveDirectory(cli, inputPath, targetZipPath)
+      return archiveDirectory(basecommand, inputPath, targetZipPath)
         .then((zipSizeBytes) =>
           resolve({
             inputPath: fs.realpathSync(targetZipPath),
@@ -43,20 +35,16 @@ async function dispatcherInputBuild(cli, inputPath) {
   });
 }
 
-/**
- *
- * @param cli
- * @param sourceDir
- * @param outputFilePath
- */
-async function archiveDirectory(cli, sourceDir, outputFilePath) {
+async function archiveDirectory(basecommand, sourceDir, outputFilePath) {
   return new Promise((resolve, reject) => {
     const output = fs.createWriteStream(outputFilePath);
     const archive = archiver('zip', { zlib: { level: 9 } });
 
     output.on('close', function () {
       const zipSizeBytes = archive.pointer();
-      cli.log(`Zipped file ${outputFilePath} of ${zipSizeBytes} total bytes`);
+      basecommand.log(
+        `Zipped file ${outputFilePath} of ${zipSizeBytes} total bytes`
+      );
       return resolve(zipSizeBytes);
     });
 

--- a/src/lib/frontend.js
+++ b/src/lib/frontend.js
@@ -16,15 +16,7 @@ const os = require('os');
 const path = require('path');
 const archiver = require('archiver');
 
-/**
- * @param closure
- * @param successPredicate
- * @param retryIntervalSeconds
- * @param maxRetries
- * @param cli
- * @param inputPath
- */
-async function frontendInputBuild(cli, inputPath) {
+async function frontendInputBuild(basecommand, inputPath) {
   return new Promise((resolve, reject) => {
     // analyse that dist/ folder and package.json folder are present on this directory
     const distInputPath = path.join(inputPath, 'dist');
@@ -32,13 +24,13 @@ async function frontendInputBuild(cli, inputPath) {
     let valid = true;
     if (!fs.existsSync(distInputPath)) {
       valid = false;
-      cli.log(
+      basecommand.log(
         `Error: There is no 'dist' folder in ${inputPath}. Please, run 'npm run build' in the project folder before running this command.`
       );
     }
     if (!fs.existsSync(pkgJsonInputPath)) {
       valid = false;
-      cli.log(
+      basecommand.log(
         `Error: There is no 'package.json' file in ${inputPath}. Ensure you're sending the right folder which contains your frontend-pipeline project.`
       );
     }
@@ -60,7 +52,9 @@ async function frontendInputBuild(cli, inputPath) {
       let zipSizeBytes;
       output.on('close', function () {
         zipSizeBytes = archive.pointer();
-        cli.log(`Zipped file ${targetZipPath} of ${zipSizeBytes} total bytes`);
+        basecommand.log(
+          `Zipped file ${targetZipPath} of ${zipSizeBytes} total bytes`
+        );
         return resolve({
           inputPath: fs.realpathSync(targetZipPath),
           inputPathSize: zipSizeBytes,

--- a/src/lib/rde-utils.js
+++ b/src/lib/rde-utils.js
@@ -116,9 +116,15 @@ async function throwOnInstallError(cloudSdkAPI, updateId, progressCallback) {
  * @param cloudSdkAPI
  * @param updateId
  * @param cli
+ * @param basecommand
  * @param progressCallback
  */
-async function loadUpdateHistory(cloudSdkAPI, updateId, cli, progressCallback) {
+async function loadUpdateHistory(
+  cloudSdkAPI,
+  updateId,
+  basecommand,
+  progressCallback
+) {
   progressCallback(false, 'retrieving update status');
   let response = await handleRetryAfter(
     null,
@@ -141,10 +147,10 @@ async function loadUpdateHistory(cloudSdkAPI, updateId, cli, progressCallback) {
     const retrySeconds = retryConfig.waitSeconds * retryConfig.retries;
     progressCallback(true);
     if (!response) {
-      cli.log(
+      basecommand.log(
         `No logs have become available within the retry period of ${retrySeconds} seconds.`
       );
-      cli.log(
+      basecommand.log(
         `Please run "aio aem:rde:history ${updateId}" to check for progress manually.`
       );
     } else if (response.status === 200) {
@@ -166,12 +172,12 @@ async function loadUpdateHistory(cloudSdkAPI, updateId, cli, progressCallback) {
       }
 
       if (lines.length > 0) {
-        cli.log(`Logs:`);
+        basecommand.log(`Logs:`);
         lines.forEach((line) => {
-          cli.log(`> ${line}`);
+          basecommand.log(`> ${line}`);
         });
       } else {
-        cli.log('No logs available for this update.');
+        basecommand.log('No logs available for this update.');
       }
     } else {
       throw new internalCodes.UNEXPECTED_API_ERROR({
@@ -179,7 +185,7 @@ async function loadUpdateHistory(cloudSdkAPI, updateId, cli, progressCallback) {
       });
     }
   } else if (response.status === 404) {
-    cli.log(`An update with ID ${updateId} does not exist.`);
+    basecommand.log(`An update with ID ${updateId} does not exist.`);
   } else {
     throw new internalCodes.UNEXPECTED_API_ERROR({
       messageValues: [response.status, response.statusText],

--- a/test/commands/aem/rde/history.test.js
+++ b/test/commands/aem/rde/history.test.js
@@ -58,7 +58,7 @@ describe('HistoryCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new HistoryCommand([], null),
+        new HistoryCommand(['--quiet'], null),
         stubbedCloudSdkMethods
       );
     });
@@ -82,7 +82,7 @@ describe('HistoryCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new HistoryCommand(['123'], null),
+        new HistoryCommand(['--quiet', '123'], null),
         stubbedCloudSdkMethods
       );
     });

--- a/test/commands/aem/rde/inspect/inventory.test.js
+++ b/test/commands/aem/rde/inspect/inventory.test.js
@@ -7,7 +7,6 @@ const {
   createCloudSdkAPIStub,
 } = require('../../../../util.js');
 const chalk = require('chalk');
-const RequestLogsCommand = require("../../../../../src/commands/aem/rde/inspect/request-logs");
 
 const errorObj = Object.create({
   status: 404,
@@ -49,13 +48,6 @@ const stubbedMethods = {
   },
 };
 
-function createCommandStub(sinon, stubMethods, args) {
-  return createCloudSdkAPIStub(
-      sinon,
-      new RequestLogsCommand(args, null),
-      stubMethods
-  );
-}
 let command, cloudSdkApiStub;
 describe('Inventory', function () {
   setupLogCapturing(sinon, cli);
@@ -147,7 +139,6 @@ describe('Inventory', function () {
 
   describe('#getInventory', function () {
     const reqId = 'test';
-    let command, cloudSdkApiStub;
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,

--- a/test/commands/aem/rde/inspect/inventory.test.js
+++ b/test/commands/aem/rde/inspect/inventory.test.js
@@ -7,6 +7,7 @@ const {
   createCloudSdkAPIStub,
 } = require('../../../../util.js');
 const chalk = require('chalk');
+const RequestLogsCommand = require("../../../../../src/commands/aem/rde/inspect/request-logs");
 
 const errorObj = Object.create({
   status: 404,
@@ -48,6 +49,13 @@ const stubbedMethods = {
   },
 };
 
+function createCommandStub(sinon, stubMethods, args) {
+  return createCloudSdkAPIStub(
+      sinon,
+      new RequestLogsCommand(args, null),
+      stubMethods
+  );
+}
 let command, cloudSdkApiStub;
 describe('Inventory', function () {
   setupLogCapturing(sinon, cli);
@@ -139,6 +147,7 @@ describe('Inventory', function () {
 
   describe('#getInventory', function () {
     const reqId = 'test';
+    let command, cloudSdkApiStub;
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,

--- a/test/commands/aem/rde/inspect/inventory.test.js
+++ b/test/commands/aem/rde/inspect/inventory.test.js
@@ -56,7 +56,7 @@ describe('Inventory', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new Inventory([], null),
+        new Inventory(['--quiet'], null),
         stubbedMethods
       );
     });
@@ -83,7 +83,7 @@ describe('Inventory', function () {
     it('Should have the expected json array result', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new Inventory(['--json'], null),
+        new Inventory(['--quiet', '--json'], null),
         stubbedMethods
       );
       await command.run();
@@ -116,7 +116,7 @@ describe('Inventory', function () {
     it('Should throw an internal error when inventory config is null.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new Inventory([], null),
+        new Inventory(['--quiet'], null),
 
         {
           ...stubbedMethods,
@@ -142,7 +142,7 @@ describe('Inventory', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new Inventory([reqId], null),
+        new Inventory(['--quiet', reqId], null),
         stubbedMethods
       );
     });
@@ -172,7 +172,7 @@ describe('Inventory', function () {
     it('Should produce the correct json output', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new Inventory(['0', '--json'], null),
+        new Inventory(['--quiet', '0', '--json'], null),
         stubbedMethods
       );
       await command.run();
@@ -184,7 +184,7 @@ describe('Inventory', function () {
     it('Should print out a error message when status is not 200', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new Inventory(['1'], null),
+        new Inventory(['--quiet', '1'], null),
 
         { ...stubbedMethods, getInventory: () => errorObj }
       );
@@ -202,7 +202,7 @@ describe('Inventory', function () {
     it('Should throw an internal error when config is null despite having non empty args.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new Inventory(['1'], null),
+        new Inventory(['--quiet', '1'], null),
         {
           ...stubbedMethods,
           getInventory: stubbedThrowErrorMethod,

--- a/test/commands/aem/rde/inspect/osgi-bundles.test.js
+++ b/test/commands/aem/rde/inspect/osgi-bundles.test.js
@@ -106,7 +106,7 @@ describe('OsgiBundlesCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new OsgiBundlesCommand([], null),
+        new OsgiBundlesCommand(['--quiet'], null),
         stubbedMethods
       );
     });
@@ -136,7 +136,7 @@ describe('OsgiBundlesCommand', function () {
     it('Should have the expected json array result', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiBundlesCommand(['--json'], null),
+        new OsgiBundlesCommand(['--quiet', '--json'], null),
         stubbedMethods
       );
       await command.run();
@@ -149,7 +149,7 @@ describe('OsgiBundlesCommand', function () {
     it('Should print out a error message when status is not 200', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiBundlesCommand([], null),
+        new OsgiBundlesCommand(['--quiet'], null),
         { ...stubbedMethods, getOsgiBundles: () => errorObj }
       );
       try {
@@ -166,7 +166,7 @@ describe('OsgiBundlesCommand', function () {
     it('Should catch a throw and print out a error message.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiBundlesCommand([], null),
+        new OsgiBundlesCommand(['--quiet'], null),
         {
           ...stubbedMethods,
           getOsgiBundles: stubbedThrowErrorMethods,
@@ -190,7 +190,7 @@ describe('OsgiBundlesCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new OsgiBundlesCommand([reqId], null),
+        new OsgiBundlesCommand(['--quiet', reqId], null),
         stubbedMethods
       );
     });
@@ -224,7 +224,7 @@ describe('OsgiBundlesCommand', function () {
     it('Should produce the correct json output', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiBundlesCommand(['0', '--json'], null),
+        new OsgiBundlesCommand(['--quiet', '0', '--json'], null),
         stubbedMethods
       );
       await command.run();
@@ -272,7 +272,7 @@ describe('OsgiBundlesCommand', function () {
     it('Should print out a error message when status is not 200', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiBundlesCommand([reqId], null),
+        new OsgiBundlesCommand(['--quiet', reqId], null),
         { ...stubbedMethods, getOsgiBundle: () => errorObj }
       );
       try {
@@ -289,7 +289,7 @@ describe('OsgiBundlesCommand', function () {
     it('Should catch a throw and print out a error message.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiBundlesCommand([reqId], null),
+        new OsgiBundlesCommand(['--quiet', reqId], null),
         {
           ...stubbedMethods,
           getOsgiBundle: stubbedThrowErrorMethods,

--- a/test/commands/aem/rde/inspect/osgi-components.test.js
+++ b/test/commands/aem/rde/inspect/osgi-components.test.js
@@ -143,7 +143,7 @@ describe('OsgiComponentsCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new OsgiComponentsCommand([], null),
+        new OsgiComponentsCommand(['--quiet'], null),
         stubbedMethods
       );
     });
@@ -173,7 +173,7 @@ describe('OsgiComponentsCommand', function () {
     it('Should have the expected json array result', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiComponentsCommand(['--json'], null),
+        new OsgiComponentsCommand(['--quiet', '--json'], null),
         stubbedMethods
       );
       await command.run();
@@ -186,7 +186,7 @@ describe('OsgiComponentsCommand', function () {
     it('Should print out a error message when status is not 200', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiComponentsCommand([], null),
+        new OsgiComponentsCommand(['--quiet'], null),
         { ...stubbedMethods, getOsgiComponents: () => errorObj }
       );
       try {
@@ -203,7 +203,7 @@ describe('OsgiComponentsCommand', function () {
     it('Should catch a throw and print out a error message.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiComponentsCommand([], null),
+        new OsgiComponentsCommand(['--quiet'], null),
         {
           ...stubbedMethods,
           getOsgiComponents: stubbedThrowErrorMethods,
@@ -227,7 +227,7 @@ describe('OsgiComponentsCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new OsgiComponentsCommand([reqId], null),
+        new OsgiComponentsCommand(['--quiet', reqId], null),
         stubbedMethods
       );
     });
@@ -261,7 +261,7 @@ describe('OsgiComponentsCommand', function () {
     it('Should produce the correct json output', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiComponentsCommand(['0', '--json'], null),
+        new OsgiComponentsCommand(['--quiet', '0', '--json'], null),
         stubbedMethods
       );
       await command.run();
@@ -282,7 +282,7 @@ describe('OsgiComponentsCommand', function () {
     it('Should print out a error message when status is not 200', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiComponentsCommand(['1'], null),
+        new OsgiComponentsCommand(['--quiet', '1'], null),
         { ...stubbedMethods, getOsgiComponent: () => errorObj }
       );
       try {
@@ -299,7 +299,7 @@ describe('OsgiComponentsCommand', function () {
     it('Should catch a throw and print out a error message.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiComponentsCommand(['1'], null),
+        new OsgiComponentsCommand(['--quiet', '1'], null),
         {
           ...stubbedMethods,
           getOsgiComponent: stubbedThrowErrorMethods,

--- a/test/commands/aem/rde/inspect/osgi-configurations.test.js
+++ b/test/commands/aem/rde/inspect/osgi-configurations.test.js
@@ -84,7 +84,7 @@ describe('OsgiConfigurationsCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new OsgiConfigurationsCommand([], null),
+        new OsgiConfigurationsCommand(['--quiet'], null),
         stubbedMethods
       );
     });
@@ -111,7 +111,7 @@ describe('OsgiConfigurationsCommand', function () {
     it('Should have the expected json array result', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiConfigurationsCommand(['--json'], null),
+        new OsgiConfigurationsCommand(['--quiet', '--json'], null),
         stubbedMethods
       );
 
@@ -125,7 +125,7 @@ describe('OsgiConfigurationsCommand', function () {
     it('Should print out a error message when status is not 200', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiConfigurationsCommand([], null),
+        new OsgiConfigurationsCommand(['--quiet'], null),
         { ...stubbedMethods, getOsgiConfigurations: () => errorObj }
       );
       try {
@@ -142,7 +142,7 @@ describe('OsgiConfigurationsCommand', function () {
     it('Should catch a throw and print out a error message.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiConfigurationsCommand([], null),
+        new OsgiConfigurationsCommand(['--quiet'], null),
         {
           ...stubbedMethods,
           getOsgiConfigurations: stubbedThrowErrorMethod,
@@ -166,7 +166,7 @@ describe('OsgiConfigurationsCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new OsgiConfigurationsCommand([reqId], null),
+        new OsgiConfigurationsCommand(['--quiet', reqId], null),
         stubbedMethods
       );
     });
@@ -196,7 +196,7 @@ describe('OsgiConfigurationsCommand', function () {
     it('Should produce the correct json output', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiConfigurationsCommand(['0', '--json'], null),
+        new OsgiConfigurationsCommand(['--quiet', '0', '--json'], null),
         stubbedMethods
       );
       await command.run();
@@ -214,7 +214,7 @@ describe('OsgiConfigurationsCommand', function () {
     it('Should print out a error message when status is not 200', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiConfigurationsCommand(['1'], null),
+        new OsgiConfigurationsCommand(['--quiet', '1'], null),
 
         { ...stubbedMethods, getOsgiConfiguration: () => errorObj }
       );
@@ -232,7 +232,7 @@ describe('OsgiConfigurationsCommand', function () {
     it('Should catch a throw and print out a error message.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiConfigurationsCommand([reqId], null),
+        new OsgiConfigurationsCommand(['--quiet', reqId], null),
         {
           ...stubbedMethods,
           getOsgiConfiguration: stubbedThrowErrorMethod,

--- a/test/commands/aem/rde/inspect/osgi-services.test.js
+++ b/test/commands/aem/rde/inspect/osgi-services.test.js
@@ -115,7 +115,7 @@ describe('OsgiServicesCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new OsgiServicesCommand([], null),
+        new OsgiServicesCommand(['--quiet'], null),
         stubbedMethods
       );
     });
@@ -146,7 +146,7 @@ describe('OsgiServicesCommand', function () {
     it('Should have the expected json array result', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiServicesCommand(['--json'], null),
+        new OsgiServicesCommand(['--quiet', '--json'], null),
         stubbedMethods
       );
       await command.run();
@@ -159,7 +159,7 @@ describe('OsgiServicesCommand', function () {
     it('Should print out a error message when status is not 200', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiServicesCommand([], null),
+        new OsgiServicesCommand(['--quiet'], null),
         {
           ...stubbedMethods,
           getOsgiServices: () => errorObj,
@@ -179,7 +179,7 @@ describe('OsgiServicesCommand', function () {
     it('Should catch a throw and print out a error message.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiServicesCommand([], null),
+        new OsgiServicesCommand(['--quiet'], null),
 
         {
           ...stubbedMethods,
@@ -204,7 +204,7 @@ describe('OsgiServicesCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new OsgiServicesCommand([reqId], null),
+        new OsgiServicesCommand(['--quiet', reqId], null),
         stubbedMethods
       );
     });
@@ -238,7 +238,7 @@ describe('OsgiServicesCommand', function () {
     it('Should produce the correct json output for a osgi service', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiServicesCommand(['0', '--json'], null),
+        new OsgiServicesCommand(['--quiet', '0', '--json'], null),
         stubbedMethods
       );
       await command.run();
@@ -267,7 +267,7 @@ describe('OsgiServicesCommand', function () {
     it('Should print out a error message when status is not 200', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiServicesCommand(['1'], null),
+        new OsgiServicesCommand(['--quiet', '1'], null),
         {
           ...stubbedMethods,
           getOsgiService: () => errorObj,
@@ -287,7 +287,7 @@ describe('OsgiServicesCommand', function () {
     it('Should catch a throw and print out a error message.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new OsgiServicesCommand(['1'], null),
+        new OsgiServicesCommand(['--quiet', '1'], null),
 
         {
           ...stubbedMethods,

--- a/test/commands/aem/rde/inspect/request-logs/disable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/disable.test.js
@@ -38,15 +38,11 @@ const stubbedMethods = {
     ),
 };
 
-function createCommandStub(sinon, stubMethods) {
-  return createCloudSdkAPIStub(
-      sinon, new DisableRequestLogsCommand(['--cicd'], null), stubMethods);
-}
+let command, cloudSdkApiStub;
 describe('DisableRequestLogsCommand', function () {
   setupLogCapturing(sinon, cli);
 
   describe('#disableRequestLogs', function () {
-    let command, cloudSdkApiStub;
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,

--- a/test/commands/aem/rde/inspect/request-logs/disable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/disable.test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const sinon = require('sinon').createSandbox();
 const DisableRequestLogsCommand = require('../../../../../../src/commands/aem/rde/inspect/request-logs/disable');
 const { cli } = require('../../../../../../src/lib/base-command.js');
+const Config = require('@adobe/aio-lib-core-config');
 const {
   setupLogCapturing,
   createCloudSdkAPIStub,
@@ -43,7 +44,24 @@ describe('DisableRequestLogsCommand', function () {
   setupLogCapturing(sinon, cli);
 
   describe('#disableRequestLogs', function () {
+    afterEach(() => {
+      Config.get.restore();
+    });
+
     beforeEach(() => {
+      sinon
+        .stub(Config, 'get')
+        .withArgs('cloudmanager_orgid')
+        .returns('1')
+        .withArgs('cloudmanager_programid')
+        .returns('1')
+        .withArgs('cloudmanager_environmentid')
+        .returns('1')
+        .withArgs('cloudmanager_programname')
+        .returns('programName')
+        .withArgs('cloudmanager_environmentname')
+        .returns('environmentName');
+
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
         new DisableRequestLogsCommand([], null),
@@ -60,7 +78,7 @@ describe('DisableRequestLogsCommand', function () {
       await command.run();
       assert.equal(
         cli.log.getCapturedLogOutput(),
-        'Running DisableRequestLogsCommand on cm-p84002-e204256 (cod18017-rde-development - cod18017-rde)\n' +
+        'Running DisableRequestLogsCommand on cm-p1-e1 (programName - environmentName)\n' +
           'Request-logs disabled.'
       );
     });

--- a/test/commands/aem/rde/inspect/request-logs/disable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/disable.test.js
@@ -46,7 +46,7 @@ describe('DisableRequestLogsCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new DisableRequestLogsCommand([], null),
+        new DisableRequestLogsCommand(['--quiet'], null),
         stubbedMethods
       );
     });
@@ -64,7 +64,7 @@ describe('DisableRequestLogsCommand', function () {
     it('Should print out a error message when status is not 200', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new DisableRequestLogsCommand([], null),
+        new DisableRequestLogsCommand(['--quiet'], null),
         stubbedErrorMethods
       );
       try {
@@ -81,7 +81,7 @@ describe('DisableRequestLogsCommand', function () {
     it('Should catch a throw and print out a error message.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new DisableRequestLogsCommand([], null),
+        new DisableRequestLogsCommand(['--quiet'], null),
         stubbedThrowErrorMethods
       );
       try {

--- a/test/commands/aem/rde/inspect/request-logs/disable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/disable.test.js
@@ -39,7 +39,10 @@ const stubbedMethods = {
     ),
 };
 
-let command, cloudSdkApiStub;
+function createCommandStub(sinon, stubMethods) {
+  return createCloudSdkAPIStub(
+      sinon, new DisableRequestLogsCommand(['--cicd'], null), stubMethods);
+}
 describe('DisableRequestLogsCommand', function () {
   setupLogCapturing(sinon, cli);
 

--- a/test/commands/aem/rde/inspect/request-logs/disable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/disable.test.js
@@ -38,11 +38,15 @@ const stubbedMethods = {
     ),
 };
 
-let command, cloudSdkApiStub;
+function createCommandStub(sinon, stubMethods) {
+  return createCloudSdkAPIStub(
+      sinon, new DisableRequestLogsCommand(['--cicd'], null), stubMethods);
+}
 describe('DisableRequestLogsCommand', function () {
   setupLogCapturing(sinon, cli);
 
   describe('#disableRequestLogs', function () {
+    let command, cloudSdkApiStub;
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,

--- a/test/commands/aem/rde/inspect/request-logs/disable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/disable.test.js
@@ -39,10 +39,7 @@ const stubbedMethods = {
     ),
 };
 
-function createCommandStub(sinon, stubMethods) {
-  return createCloudSdkAPIStub(
-      sinon, new DisableRequestLogsCommand(['--cicd'], null), stubMethods);
-}
+let command, cloudSdkApiStub;
 describe('DisableRequestLogsCommand', function () {
   setupLogCapturing(sinon, cli);
 

--- a/test/commands/aem/rde/inspect/request-logs/disable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/disable.test.js
@@ -46,7 +46,7 @@ describe('DisableRequestLogsCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new DisableRequestLogsCommand(['--quiet'], null),
+        new DisableRequestLogsCommand([], null),
         stubbedMethods
       );
     });
@@ -58,7 +58,11 @@ describe('DisableRequestLogsCommand', function () {
 
     it('Should return a message to the console if the disable action was successful', async function () {
       await command.run();
-      assert.equal(cli.log.getCapturedLogOutput(), 'Request-logs disabled.');
+      assert.equal(
+        cli.log.getCapturedLogOutput(),
+        'Running DisableRequestLogsCommand on cm-p84002-e204256 (cod18017-rde-development - cod18017-rde)\n' +
+          'Request-logs disabled.'
+      );
     });
 
     it('Should print out a error message when status is not 200', async function () {

--- a/test/commands/aem/rde/inspect/request-logs/enable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/enable.test.js
@@ -49,7 +49,6 @@ describe('EnableRequestLogsCommand', function () {
         sinon,
         new EnableRequestLogsCommand(
           [
-            '--quiet',
             '-i',
             arg,
             '-d',
@@ -110,13 +109,17 @@ describe('EnableRequestLogsCommand', function () {
 
     it('Should produce the correct textual output.', async function () {
       await command.run();
-      assert.equal(cli.log.getCapturedLogOutput(), 'Request-logs enabled.');
+      assert.equal(
+        cli.log.getCapturedLogOutput(),
+        'Running EnableRequestLogsCommand on cm-p84002-e204256 (cod18017-rde-development - cod18017-rde)\n' +
+          'Request-logs enabled.'
+      );
     });
 
     it('Should print out a error message when status is not 200.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new EnableRequestLogsCommand(['--quiet'], null),
+        new EnableRequestLogsCommand([], null),
         stubbedErrorMethods
       );
       try {
@@ -133,7 +136,7 @@ describe('EnableRequestLogsCommand', function () {
     it('Should catch a throw and print out a error message.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new EnableRequestLogsCommand(['--quiet'], null),
+        new EnableRequestLogsCommand([], null),
         stubbedThrowErrorMethods
       );
       try {

--- a/test/commands/aem/rde/inspect/request-logs/enable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/enable.test.js
@@ -49,6 +49,7 @@ describe('EnableRequestLogsCommand', function () {
         sinon,
         new EnableRequestLogsCommand(
           [
+            '--quiet',
             '-i',
             arg,
             '-d',
@@ -115,7 +116,7 @@ describe('EnableRequestLogsCommand', function () {
     it('Should print out a error message when status is not 200.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new EnableRequestLogsCommand([], null),
+        new EnableRequestLogsCommand(['--quiet'], null),
         stubbedErrorMethods
       );
       try {
@@ -132,7 +133,7 @@ describe('EnableRequestLogsCommand', function () {
     it('Should catch a throw and print out a error message.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new EnableRequestLogsCommand([], null),
+        new EnableRequestLogsCommand(['--quiet'], null),
         stubbedThrowErrorMethods
       );
       try {

--- a/test/commands/aem/rde/inspect/request-logs/enable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/enable.test.js
@@ -36,9 +36,7 @@ const stubbedMethods = {
     ),
 };
 
-function createCommandStub(sinon, stubMethods, args) {
-    return createCloudSdkAPIStub(sinon, new EnableRequestLogsCommand(args, null), stubMethods);
-}
+let command, cloudSdkApiStub;
 describe('EnableRequestLogsCommand', function () {
   setupLogCapturing(sinon, cli);
 

--- a/test/commands/aem/rde/inspect/request-logs/enable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/enable.test.js
@@ -36,7 +36,9 @@ const stubbedMethods = {
     ),
 };
 
-let command, cloudSdkApiStub;
+function createCommandStub(sinon, stubMethods, args) {
+    return createCloudSdkAPIStub(sinon, new EnableRequestLogsCommand(args, null), stubMethods);
+}
 describe('EnableRequestLogsCommand', function () {
   setupLogCapturing(sinon, cli);
 

--- a/test/commands/aem/rde/inspect/request-logs/enable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/enable.test.js
@@ -35,9 +35,7 @@ const stubbedMethods = {
     ),
 };
 
-function createCommandStub(sinon, stubMethods, args) {
-    return createCloudSdkAPIStub(sinon, new EnableRequestLogsCommand(args, null), stubMethods);
-}
+let command, cloudSdkApiStub;
 describe('EnableRequestLogsCommand', function () {
   setupLogCapturing(sinon, cli);
 

--- a/test/commands/aem/rde/inspect/request-logs/enable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/enable.test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const sinon = require('sinon').createSandbox();
 const EnableRequestLogsCommand = require('../../../../../../src/commands/aem/rde/inspect/request-logs/enable');
 const { cli } = require('../../../../../../src/lib/base-command.js');
+const Config = require('@adobe/aio-lib-core-config');
 const {
   setupLogCapturing,
   createCloudSdkAPIStub,
@@ -44,7 +45,25 @@ describe('EnableRequestLogsCommand', function () {
     const format =
       '%d{dd.MM.yyyy HH:mm:ss.SSS} *%level* [%thread] %logger %msg%n';
     const includePathPatterns = '*test';
+
+    afterEach(() => {
+      Config.get.restore();
+    });
+
     beforeEach(() => {
+      sinon
+        .stub(Config, 'get')
+        .withArgs('cloudmanager_orgid')
+        .returns('1')
+        .withArgs('cloudmanager_programid')
+        .returns('1')
+        .withArgs('cloudmanager_environmentid')
+        .returns('1')
+        .withArgs('cloudmanager_programname')
+        .returns('programName')
+        .withArgs('cloudmanager_environmentname')
+        .returns('environmentName');
+
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
         new EnableRequestLogsCommand(
@@ -111,7 +130,7 @@ describe('EnableRequestLogsCommand', function () {
       await command.run();
       assert.equal(
         cli.log.getCapturedLogOutput(),
-        'Running EnableRequestLogsCommand on cm-p84002-e204256 (cod18017-rde-development - cod18017-rde)\n' +
+        'Running EnableRequestLogsCommand on cm-p1-e1 (programName - environmentName)\n' +
           'Request-logs enabled.'
       );
     });

--- a/test/commands/aem/rde/inspect/request-logs/enable.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/enable.test.js
@@ -35,7 +35,9 @@ const stubbedMethods = {
     ),
 };
 
-let command, cloudSdkApiStub;
+function createCommandStub(sinon, stubMethods, args) {
+    return createCloudSdkAPIStub(sinon, new EnableRequestLogsCommand(args, null), stubMethods);
+}
 describe('EnableRequestLogsCommand', function () {
   setupLogCapturing(sinon, cli);
 

--- a/test/commands/aem/rde/inspect/request-logs/index.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/index.test.js
@@ -78,6 +78,13 @@ const stubbedMethods = {
     ),
 };
 
+function createCommandStub(sinon, stubMethods, args) {
+    return createCloudSdkAPIStub(
+        sinon,
+        new RequestLogsCommand(args, null),
+        stubMethods
+    );
+}
 let command, cloudSdkApiStub;
 describe('RequestLogsCommand', function () {
   setupLogCapturing(sinon, cli);

--- a/test/commands/aem/rde/inspect/request-logs/index.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/index.test.js
@@ -86,7 +86,7 @@ describe('RequestLogsCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new RequestLogsCommand([], null),
+        new RequestLogsCommand(['--quiet'], null),
         stubbedMethods
       );
     });
@@ -114,7 +114,7 @@ describe('RequestLogsCommand', function () {
     it('Should have the expected json array result.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new RequestLogsCommand(['--json'], null),
+        new RequestLogsCommand(['--quiet', '--json'], null),
         stubbedMethods
       );
       await command.run();
@@ -132,7 +132,7 @@ describe('RequestLogsCommand', function () {
     it('Should print out a error message when status is not 200', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new RequestLogsCommand([], null),
+        new RequestLogsCommand(['--quiet'], null),
         { ...stubbedMethods, getRequestLogs: () => errorObj }
       );
       try {
@@ -149,7 +149,7 @@ describe('RequestLogsCommand', function () {
     it('Should catch a throw and print out a error message.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new RequestLogsCommand([], null),
+        new RequestLogsCommand(['--quiet'], null),
         {
           ...stubbedMethods,
           getRequestLogs: stubbedThrowErrorMethod,
@@ -173,7 +173,7 @@ describe('RequestLogsCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new RequestLogsCommand([reqId], null),
+        new RequestLogsCommand(['--quiet', reqId], null),
         stubbedMethods
       );
     });
@@ -203,7 +203,7 @@ describe('RequestLogsCommand', function () {
     it('Should produce the correct json output.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new RequestLogsCommand(['0', '--json'], null),
+        new RequestLogsCommand(['--quiet', '0', '--json'], null),
         stubbedMethods
       );
 
@@ -229,7 +229,7 @@ describe('RequestLogsCommand', function () {
     it('Should print out a error message when status is not 200.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new RequestLogsCommand(['1'], null),
+        new RequestLogsCommand(['--quiet', '1'], null),
         { ...stubbedMethods, getRequestLog: () => errorObj }
       );
       try {
@@ -246,7 +246,7 @@ describe('RequestLogsCommand', function () {
     it('Should catch a throw and print out a error message.', async function () {
       const [command] = createCloudSdkAPIStub(
         sinon,
-        new RequestLogsCommand(['1'], null),
+        new RequestLogsCommand(['--quiet', '1'], null),
         {
           ...stubbedMethods,
           getRequestLog: stubbedThrowErrorMethod,

--- a/test/commands/aem/rde/inspect/request-logs/index.test.js
+++ b/test/commands/aem/rde/inspect/request-logs/index.test.js
@@ -78,13 +78,6 @@ const stubbedMethods = {
     ),
 };
 
-function createCommandStub(sinon, stubMethods, args) {
-    return createCloudSdkAPIStub(
-        sinon,
-        new RequestLogsCommand(args, null),
-        stubMethods
-    );
-}
 let command, cloudSdkApiStub;
 describe('RequestLogsCommand', function () {
   setupLogCapturing(sinon, cli);

--- a/test/commands/aem/rde/logs.test.js
+++ b/test/commands/aem/rde/logs.test.js
@@ -93,7 +93,7 @@ describe('LogsCommand', function () {
   beforeEach(() => {
     [command, cloudSdkApiStub] = createCloudSdkAPIStub(
       sinon,
-      new LogsCommand(['-d com.adobe', '--no-color'], null),
+      new LogsCommand(['--quiet', '-d com.adobe', '--no-color'], null),
       stubbedMethods
     );
   });
@@ -159,7 +159,7 @@ describe('LogsCommand', function () {
     it('Should print out the logs in color', async function () {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new LogsCommand(['-d com.adobe'], null),
+        new LogsCommand(['--quiet', '-d com.adobe'], null),
         stubbedMethods
       );
 
@@ -240,7 +240,21 @@ describe('LogsCommand', function () {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
         new LogsCommand(
-          ['-i', arg, '-d', arg, '-f', format, '-e', arg, '-i', arg, '-w', arg],
+          [
+            '--quiet',
+            '-i',
+            arg,
+            '-d',
+            arg,
+            '-f',
+            format,
+            '-e',
+            arg,
+            '-i',
+            arg,
+            '-w',
+            arg,
+          ],
           null
         ),
         stubbedMethods

--- a/test/commands/aem/rde/reset.test.js
+++ b/test/commands/aem/rde/reset.test.js
@@ -20,4 +20,18 @@ describe('ResetCommand', function () {
       assert.ok(cloudSdkApiStub.resetEnv.calledOnce);
     });
   });
+
+  describe('#run quiet', function () {
+    it('cloudSDKAPI.resetEnv() has been called', async function () {
+      const [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new ResetCommand(['--quiet'], null),
+        {
+          resetEnv: () => {},
+        }
+      );
+      await command.run();
+      assert.ok(cloudSdkApiStub.resetEnv.calledOnce);
+    });
+  });
 });

--- a/test/commands/aem/rde/restart.test.js
+++ b/test/commands/aem/rde/restart.test.js
@@ -24,4 +24,21 @@ describe('RestartCommand', function () {
       assert.ok(cloudSdkApiStub.restartEnv.calledOnce);
     });
   });
+
+  describe('#run quiet', function () {
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new RestartCommand(['--quiet'], null),
+        {
+          restartEnv: () => {},
+        }
+      );
+    });
+
+    it('cloudSDKAPI.restartEnv() has been called', async function () {
+      await command.run();
+      assert.ok(cloudSdkApiStub.restartEnv.calledOnce);
+    });
+  });
 });

--- a/test/commands/aem/rde/status.test.js
+++ b/test/commands/aem/rde/status.test.js
@@ -55,7 +55,7 @@ describe('StatusCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new StatusCommand([], null),
+        new StatusCommand(['--quiet'], null),
         stubbedMethods
       );
     });
@@ -84,7 +84,7 @@ describe('StatusCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new StatusCommand(['--json'], null),
+        new StatusCommand(['--quiet', '--json'], null),
         stubbedMethods
       );
     });

--- a/test/commands/aem/rde/status.test.js
+++ b/test/commands/aem/rde/status.test.js
@@ -55,7 +55,7 @@ describe('StatusCommand', function () {
     beforeEach(() => {
       [command, cloudSdkApiStub] = createCloudSdkAPIStub(
         sinon,
-        new StatusCommand(['--quiet'], null),
+        new StatusCommand([], null),
         stubbedMethods
       );
     });
@@ -69,8 +69,32 @@ describe('StatusCommand', function () {
       await command.run();
       assert.equal(
         cli.log.getCapturedLogOutput(),
-        'Info for cm-p12345-e54321\n' +
+        'Running StatusCommand on cm-p12345-e54321\n' +
+          'Info for cm-p12345-e54321\n' +
           'Environment: Ready\n' +
+          '- Bundles Author:\n' +
+          ' test-bundle-1.0.0\n' +
+          '- Bundles Publish:\n' +
+          '- Configurations Author:\n' +
+          '- Configurations Publish:'
+      );
+    });
+  });
+
+  describe('#run as textual result quiet', function () {
+    beforeEach(() => {
+      [command, cloudSdkApiStub] = createCloudSdkAPIStub(
+        sinon,
+        new StatusCommand(['--quiet'], null),
+        stubbedMethods
+      );
+    });
+
+    it('should produce the correct textual output', async function () {
+      await command.run();
+      assert.equal(
+        cli.log.getCapturedLogOutput(),
+        'Environment: Ready\n' +
           '- Bundles Author:\n' +
           ' test-bundle-1.0.0\n' +
           '- Bundles Publish:\n' +

--- a/test/lib/base-command-params.test.js
+++ b/test/lib/base-command-params.test.js
@@ -40,19 +40,8 @@ const stubbedMethods = {
     }),
 };
 
-/**
- *
- * @param sinon
- * @param CommandClass
- * @param args
- * @param stubMethods
- */
 function createCommandStub(sinon, CommandClass, args, stubMethods) {
-  return createCloudSdkAPIStub(
-    sinon,
-    new CommandClass(args, null),
-    stubMethods
-  );
+  return createCloudSdkAPIStub(sinon, new CommandClass(args, null), stubMethods);
 }
 
 let command, cloudSdkApiStub;
@@ -62,14 +51,14 @@ describe('ParamTestCommand take params', function () {
     [command, cloudSdkApiStub] = createCommandStub(
       sinon,
       StatusCommand,
-      [
-        '--organizationId',
-        'testOrg',
-        '--programId',
-        'testProg',
-        '--environmentId',
-        'testEnv',
-      ],
+        [
+          '--organizationId',
+          'testOrg',
+          '--programId',
+          'testProg',
+          '--environmentId',
+          'testEnv',
+        ],
       stubbedMethods
     );
   });
@@ -85,13 +74,13 @@ describe('ParamTestCommand take params', function () {
 describe('ParamTestCommand use config values when flags are not provided, empty, or whitespace', function () {
   beforeEach(() => {
     sinon
-      .stub(Config, 'get')
-      .withArgs('cloudmanager_orgid')
-      .returns('customOrg123')
-      .withArgs('cloudmanager_programid')
-      .returns('customProg123')
-      .withArgs('cloudmanager_environmentid')
-      .returns('customEnv123');
+        .stub(Config, 'get')
+        .withArgs('cloudmanager_orgid')
+        .returns('customOrg123')
+        .withArgs('cloudmanager_programid')
+        .returns('customProg123')
+        .withArgs('cloudmanager_environmentid')
+        .returns('customEnv123');
   });
 
   afterEach(() => {
@@ -100,30 +89,17 @@ describe('ParamTestCommand use config values when flags are not provided, empty,
 
   const testCases = [
     { args: [], description: 'flags are not provided' },
-    {
-      args: ['--organizationId', '', '--programId', '', '--environmentId', ''],
-      description: 'flags are empty',
-    },
-    {
-      args: [
-        '--organizationId',
-        ' ',
-        '--programId',
-        ' ',
-        '--environmentId',
-        ' ',
-      ],
-      description: 'flags are whitespace',
-    },
+    { args: ['--organizationId', '', '--programId', '', '--environmentId', ''], description: 'flags are empty' },
+    { args: ['--organizationId', ' ', '--programId', ' ', '--environmentId', ' '], description: 'flags are whitespace' }
   ];
 
   testCases.forEach(({ args, description }) => {
-    it(`should use .aio configuration values when ${description}`, async function () {
+    it('should use .aio configuration values when ${description}', async function () {
       [command, cloudSdkApiStub] = createCommandStub(
-        sinon,
-        StatusCommand,
-        args,
-        stubbedMethods
+          sinon,
+          StatusCommand,
+          args,
+          stubbedMethods
       );
       await command.run();
       assert.strictEqual(command._orgId, 'customOrg123');

--- a/test/lib/base-command-params.test.js
+++ b/test/lib/base-command-params.test.js
@@ -40,8 +40,19 @@ const stubbedMethods = {
     }),
 };
 
+/**
+ *
+ * @param sinon
+ * @param CommandClass
+ * @param args
+ * @param stubMethods
+ */
 function createCommandStub(sinon, CommandClass, args, stubMethods) {
-  return createCloudSdkAPIStub(sinon, new CommandClass(args, null), stubMethods);
+  return createCloudSdkAPIStub(
+    sinon,
+    new CommandClass(args, null),
+    stubMethods
+  );
 }
 
 let command, cloudSdkApiStub;
@@ -51,14 +62,14 @@ describe('ParamTestCommand take params', function () {
     [command, cloudSdkApiStub] = createCommandStub(
       sinon,
       StatusCommand,
-        [
-          '--organizationId',
-          'testOrg',
-          '--programId',
-          'testProg',
-          '--environmentId',
-          'testEnv',
-        ],
+      [
+        '--organizationId',
+        'testOrg',
+        '--programId',
+        'testProg',
+        '--environmentId',
+        'testEnv',
+      ],
       stubbedMethods
     );
   });
@@ -74,13 +85,13 @@ describe('ParamTestCommand take params', function () {
 describe('ParamTestCommand use config values when flags are not provided, empty, or whitespace', function () {
   beforeEach(() => {
     sinon
-        .stub(Config, 'get')
-        .withArgs('cloudmanager_orgid')
-        .returns('customOrg123')
-        .withArgs('cloudmanager_programid')
-        .returns('customProg123')
-        .withArgs('cloudmanager_environmentid')
-        .returns('customEnv123');
+      .stub(Config, 'get')
+      .withArgs('cloudmanager_orgid')
+      .returns('customOrg123')
+      .withArgs('cloudmanager_programid')
+      .returns('customProg123')
+      .withArgs('cloudmanager_environmentid')
+      .returns('customEnv123');
   });
 
   afterEach(() => {
@@ -89,17 +100,30 @@ describe('ParamTestCommand use config values when flags are not provided, empty,
 
   const testCases = [
     { args: [], description: 'flags are not provided' },
-    { args: ['--organizationId', '', '--programId', '', '--environmentId', ''], description: 'flags are empty' },
-    { args: ['--organizationId', ' ', '--programId', ' ', '--environmentId', ' '], description: 'flags are whitespace' }
+    {
+      args: ['--organizationId', '', '--programId', '', '--environmentId', ''],
+      description: 'flags are empty',
+    },
+    {
+      args: [
+        '--organizationId',
+        ' ',
+        '--programId',
+        ' ',
+        '--environmentId',
+        ' ',
+      ],
+      description: 'flags are whitespace',
+    },
   ];
 
   testCases.forEach(({ args, description }) => {
-    it('should use .aio configuration values when ${description}', async function () {
+    it(`should use .aio configuration values when ${description}`, async function () {
       [command, cloudSdkApiStub] = createCommandStub(
-          sinon,
-          StatusCommand,
-          args,
-          stubbedMethods
+        sinon,
+        StatusCommand,
+        args,
+        stubbedMethods
       );
       await command.run();
       assert.strictEqual(command._orgId, 'customOrg123');


### PR DESCRIPTION
Bases on #74 

## Description

**base command:**
- logs program and environment names when available 

**24h action check**
- A config that stores the last action execution timepoint was added
- when the last call to an action is more than 24h ago, ask the user if the action shall be executed on cm-p1-e1. This avoids bad situation like reset a wrong RDE (happened to me already...)

**quiet flag**
- Introduced common quiet flag that can be used for any command
- This will not show spinners
- Ignores the 24h action check
- It will suppress most log messages, i.e. 'Environment reset.' or 'Info for cm-...'. Also, errors from the API will be suppressed and the exit code is the only indication for failure.
- It still shows all log messages that actually show data output.

## Motivation and Context
- Avoids time consuming restore if the wrong RDE gets reset after 24h
- Gives the user more context about the selected RDE
- avoids too many log messages when needed

## How Has This Been Tested?

- Locally running commands
- npm tests

## Types of changes

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
