### PR TITLE
enhance log command to be more user friendly

### DIFF
--- a/src/commands/aem/rde/logs.js
+++ b/src/commands/aem/rde/logs.js
@@ -205,7 +205,9 @@ class LogsCommand extends BaseCommand {
       }
 
       if (!body.names || body.names.length === 0) {
-        throw new internalCodes.INTERNAL_CREATE_LOG_NO_LOGS_ERROR();
+        this.doLog(chalk.yellow(`No log configuration provided.`));
+        this.doLog(chalk.gray(`Default to: aio aem rde logs -i ""`));
+        flags.info = [''];
       }
 
       const response = await this.withCloudSdk((cloudSdkAPI) =>
@@ -299,6 +301,8 @@ Object.assign(LogsCommand, {
       description: `Specify the format string. eg: '%d{dd.MM.yyyy HH:mm:ss.SSS} *%level* [%thread] %logger %msg%n`,
       multiple: false,
       required: false,
+      helpValue: `<log4j format definition>`,
+      helpGroup: 'format and color',
     }),
     // trace: Flags.string({
     //   description: `Optional logger on TRACE level.`,
@@ -310,40 +314,52 @@ Object.assign(LogsCommand, {
       description: `Optional logger on DEBUG level.`,
       multiple: true,
       required: false,
+      helpValue: `<package or class name>`,
+      helpGroup: 'level',
     }),
     info: Flags.string({
       char: 'i',
       description: `Optional logger on INFO level.`,
       multiple: true,
       required: false,
+      helpValue: `<package or class name>`,
+      helpGroup: 'level',
     }),
     warn: Flags.string({
       char: 'w',
       description: `Optional logger on WARN level.`,
       multiple: true,
       required: false,
+      helpValue: `<package or class name>`,
+      helpGroup: 'level',
     }),
     error: Flags.string({
       char: 'e',
       description: `Optional logger on ERROR level.`,
       multiple: true,
       required: false,
+      helpValue: `<package or class name>`,
+      helpGroup: 'level',
     }),
     color: Flags.boolean({
       aliases: ['colour'],
       description: 'Colorize log output',
       default: true,
       allowNo: true,
+      helpGroup: 'format and color',
     }),
     choose: Flags.boolean({
       description: 'Choose from existing log configurations to tail',
       default: false,
+      helpGroup: 'output',
     }),
     highlight: Flags.string({
       char: 'H',
       description: `Highlight log lines containing the specified string.`,
       multiple: true,
       required: false,
+      helpValue: `<substring of a log line>`,
+      helpGroup: 'format and color',
     }),
     quiet: commonFlags.quiet,
   },

--- a/src/commands/aem/rde/logs.js
+++ b/src/commands/aem/rde/logs.js
@@ -301,7 +301,7 @@ Object.assign(LogsCommand, {
       description: `Specify the format string. eg: '%d{dd.MM.yyyy HH:mm:ss.SSS} *%level* [%thread] %logger %msg%n`,
       multiple: false,
       required: false,
-      helpValue: `<log4j format definition>`,
+      helpValue: `<logback format definition>`,
       helpGroup: 'format and color',
     }),
     // trace: Flags.string({

--- a/src/lib/base-command.js
+++ b/src/lib/base-command.js
@@ -287,6 +287,7 @@ module.exports = {
       options: ['author', 'publish'],
       default: 'author',
       common: true,
+      helpGroup: 'target',
     }),
     target: Flags.string({
       char: 's',
@@ -296,6 +297,7 @@ module.exports = {
       required: false,
       options: ['author', 'publish'],
       common: true,
+      helpGroup: 'target',
     }),
     scope: Flags.string({
       description: 'Optional filter for the scope.',
@@ -315,16 +317,19 @@ module.exports = {
       description: 'The organization id to use while running this command',
       multiple: false,
       required: false,
+      helpGroup: 'target',
     }),
     programId: Flags.string({
       description: 'The program id to use while running this command',
       multiple: false,
       required: false,
+      helpGroup: 'target',
     }),
     environmentId: Flags.string({
       description: 'The environment id to use while running this command',
       multiple: false,
       required: false,
+      helpGroup: 'target',
     }),
     quiet: Flags.boolean({
       description: 'Generates no log output and asks for no user input',
@@ -332,6 +337,7 @@ module.exports = {
       multiple: false,
       required: false,
       default: false,
+      helpGroup: 'output',
     }),
   },
 };

--- a/src/lib/internal-errors.js
+++ b/src/lib/internal-errors.js
@@ -93,10 +93,6 @@ E(
   'There are too many log configurations. Please, delete some logs before creating new ones.'
 );
 E(
-  'INTERNAL_CREATE_LOG_NO_LOGS_ERROR',
-  'There were no valid definitions found for the log configuration. For further instructions on how to define a log configuration, use "aio aem rde logs --help".'
-);
-E(
   'INTERNAL_GET_OSGI_BUNDLES_ERROR',
   'There was an unexpected error when running get osgi bundles command. Please, try again later and if the error persists, report it. Error %s'
 );

--- a/test/commands/aem/rde/logs.test.js
+++ b/test/commands/aem/rde/logs.test.js
@@ -58,22 +58,6 @@ const status200 = {
   status: 200,
 };
 
-const tooManyLogsSuccessObj = {
-  status: 200,
-  json: () =>
-    Object.create({
-      status: 'Ready',
-      items: ['0', '1', '2'].map((id) =>
-        Object.create({
-          id,
-          names: [{ logger: '', level: 'INFO' }],
-          format:
-            '%d{dd.MM.yyyy HH:mm:ss.SSS} *%level* [%thread] %logger %msg%n',
-        })
-      ),
-    }),
-};
-
 const stubbedMethods = {
   createAemLog: createLogsSuccessObj,
   getAemLogs: aemLogsSuccessObj,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- allow to use 'aio aem rde logs' without any parameters, which will basically do a: aio aem rde logs i "" <- info log for root logger
- enhance the help to make clear what the value is that is needed for --info, --debug etc. 
- enhance error messages for missing log configs --> dropped it as we now default to -i ""


