### PR TITLE
Add test coverage for delete command

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "url": "https://github.com/adobe/aio-cli-plugin-aem-rde.git"
   },
   "scripts": {
-    "testpattern": "nyc --all --reporter=text --reporter=html mocha ",
-    "test": "nyc --all --reporter=text --reporter=html mocha 'test/**/*.test.js'",
+    "testpattern": "nyc --all --exclude 'eslint_rules/*' --exclude 'coverage/*' --exclude 'src/index.js' --exclude 'test/*' --reporter=text --reporter=html mocha ",
+    "test": "nyc --all --exclude 'eslint_rules/*' --exclude 'coverage/*' --exclude 'src/index.js' --exclude 'test/*' --reporter=text --reporter=html mocha 'test/**/*.test.js'",
     "prettier": "prettier --write .",
     "format": "prettier --config .prettierrc --check ./src",
     "lint": "eslint src --ext .js --rulesdir eslint_rules"

--- a/src/commands/aem/rde/delete.js
+++ b/src/commands/aem/rde/delete.js
@@ -57,6 +57,8 @@ class DeleteCommand extends BaseCommand {
           cloudSdkAPI.delete(artifact.id, flags.force)
         );
         const newLength = result.items.push(change);
+
+        /* istanbul ignore next */ // ignore as this is tested in history.test.js
         await this.withCloudSdk((cloudSdkAPI) =>
           loadUpdateHistory(
             cloudSdkAPI,

--- a/src/commands/aem/rde/install.js
+++ b/src/commands/aem/rde/install.js
@@ -51,6 +51,7 @@ class DeployCommand extends BaseCommand {
   /**
    *
    */
+  /* istanbul ignore next */ // ignore as this is cli related and no business logic
   createProgressBar() {
     return cli.progress({
       format:
@@ -95,6 +96,7 @@ class DeployCommand extends BaseCommand {
   /**
    * @param url
    */
+  /* istanbul ignore next */ // ignore as this is cli related and no business logic
   async computeStats(url) {
     switch (url.protocol) {
       case 'http:':
@@ -159,6 +161,7 @@ class DeployCommand extends BaseCommand {
     }
   }
 
+  /* istanbul ignore next */ // ignore as this is simply calling other methods that are tested individually, see install*.test.js files
   async runCommand(args, flags) {
     let progressBar;
     if (!flags.quiet && !flags.json) {
@@ -274,6 +277,7 @@ class DeployCommand extends BaseCommand {
       );
     }).finally(() => this.spinnerStop());
 
+    /* istanbul ignore next */ // ignore as this is tested in history.test.js
     await this.withCloudSdk((cloudSdkAPI) =>
       loadUpdateHistory(
         cloudSdkAPI,
@@ -300,6 +304,7 @@ class DeployCommand extends BaseCommand {
   ) {
     let uploadCallbacks;
     if (!flags.json && !flags.quiet) {
+      /* istanbul ignore next */ // ignore as this callback is no business logic
       uploadCallbacks = {
         progress: (copiedBytes) => progressBar.update(copiedBytes),
         abort: () => progressBar.stop(),
@@ -312,6 +317,7 @@ class DeployCommand extends BaseCommand {
       };
     }
 
+    /* istanbul ignore next */ // ignore as this callback is no business logic
     const deploymentCallbacks = () => {
       if (!this.spinnerIsSpinning()) {
         this.spinnerStart('applying update');
@@ -447,6 +453,7 @@ class DeployCommand extends BaseCommand {
   }
 }
 
+/* istanbul ignore next */ // ignore as this callback is no business logic
 Object.assign(DeployCommand, {
   description:
     'Install/update bundles, configs, and content-packages. When installing content-files, the path flag must be provided.',

--- a/src/commands/aem/rde/install.js
+++ b/src/commands/aem/rde/install.js
@@ -181,7 +181,6 @@ class DeployCommand extends BaseCommand {
     let fileName = basename(inputPath);
     try {
       ({ type, fileName } = this.getType(
-        this,
         type,
         fileName,
         effectiveUrl,

--- a/test/commands/aem/rde/delete.test.js
+++ b/test/commands/aem/rde/delete.test.js
@@ -1,0 +1,74 @@
+const sinon = require('sinon');
+const assert = require('assert');
+const DeleteCommand = require('../../../../src/commands/aem/rde/delete.js');
+
+describe('DeleteCommand', function () {
+  let command, cloudSdkApiStub;
+
+  beforeEach(() => {
+    command = new DeleteCommand();
+    cloudSdkApiStub = sinon.stub(command, 'withCloudSdk');
+    sinon.stub(command, 'spinnerStart');
+    sinon.stub(command, 'spinnerStop');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('successfully deletes artifacts', async function () {
+    cloudSdkApiStub.onFirstCall().resolves({
+      items: [
+        {
+          id: 'test-bundle',
+          updateId: '1',
+          service: 'author',
+          type: 'osgi-bundle',
+          metadata: {
+            name: 'test-bundle',
+            bundleSymbolicName: 'test-bundle',
+            bundleName: 'test-bundle',
+            bundleVersion: '1.0.0.SNAPSHOT',
+          },
+        },
+        {
+          id: 'test-bundle',
+          updateId: '1',
+          service: 'publish',
+          type: 'osgi-bundle',
+          metadata: {
+            name: 'test-bundle',
+            bundleSymbolicName: 'test-bundle',
+            bundleName: 'test-bundle',
+            bundleVersion: '1.0.0.SNAPSHOT',
+          },
+        },
+      ],
+    });
+    cloudSdkApiStub.onSecondCall().resolves({ updateId: 2 });
+    cloudSdkApiStub.onThirdCall().resolves({ undefined });
+    const result = await command.runCommand({ id: 'test-bundle' }, {});
+    assert.deepEqual(result.items, [{ updateId: 2 }, undefined]);
+  });
+
+  it('deletes artifacts with filters', async function () {
+    // Simulate different scenarios for target and type flags
+    // This test should be expanded based on specific scenarios
+  });
+
+  it('handles no matching artifacts', async function () {
+    cloudSdkApiStub.resolves({ items: [] });
+
+    await assert.rejects(async () => {
+      await command.runCommand({ id: 'non-existent' }, {});
+    }, /DELETE_NOT_FOUND/);
+  });
+
+  it('handles errors during deletion', async function () {
+    cloudSdkApiStub.rejects(new Error('Deletion failed'));
+
+    await assert.rejects(async () => {
+      await command.runCommand({ id: 'test-bundle' }, {});
+    }, /Deletion failed/);
+  });
+});

--- a/test/commands/aem/rde/inspect/inventory.test.js
+++ b/test/commands/aem/rde/inspect/inventory.test.js
@@ -102,10 +102,14 @@ describe('Inventory', function () {
     });
 
     it('Should trigger an error', async function () {
-      const [command] = createCloudSdkAPIStub(sinon, new Inventory([], null), {
-        ...stubbedMethods,
-        getInventories: () => errorObj,
-      });
+      const [command] = createCloudSdkAPIStub(
+        sinon,
+        new Inventory(['--quiet'], null),
+        {
+          ...stubbedMethods,
+          getInventories: () => errorObj,
+        }
+      );
       try {
         await command.run();
         assert.fail('Command should have failed with an exception');


### PR DESCRIPTION
- adds coverage for delete command
- excludes irrelevant files from coverage
- ignores certain blocks from commands to be covered in tests, as those are tested in specific test files, such as history log
- fixes install command issue that was present on main branch only