### PR TITLE
SKYOPS-91738 state reset success or failure to the user

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,3 +15,7 @@ to npmjs.com is automatically performed by the github action
 
 The progress and status of the deployment can be inspected on the
 [Actions tab](//github.com/adobe/aio-cli-plugin-aem-rde/actions).
+
+# Steps to do after the release
+- Create a release note in https://github.com/adobe/aio-cli-plugin-aem-rde/releases
+- Send a message in #aem-rde in both, slack and discord

--- a/src/commands/aem/rde/reset.js
+++ b/src/commands/aem/rde/reset.js
@@ -25,13 +25,18 @@ class ResetCommand extends BaseCommand {
       const result = this.jsonResult();
       this.doLog(`Reset cm-p${this._programId}-e${this._environmentId}`);
       this.spinnerStart('resetting environment');
-      await this.withCloudSdk((cloudSdkAPI) =>
+      const status = await this.withCloudSdk((cloudSdkAPI) =>
         cloudSdkAPI.resetEnv(flags.wait)
       );
       this.spinnerStop();
       if (flags.wait) {
-        result.status = 'reset';
-        this.doLog(`Environment reset.`);
+        if (status === 'ready') {
+          result.status = 'reset';
+          this.doLog(`Environment reset.`);
+        } else if (status === 'reset_failed') {
+          result.status = 'reset_failed';
+          this.doLog(`Failed to reset the environment.`);
+        }
       } else {
         result.status = 'resetting';
         this.doLog(

--- a/src/lib/cloud-sdk-api.js
+++ b/src/lib/cloud-sdk-api.js
@@ -328,7 +328,7 @@ class CloudSdkAPI {
     let errMessage = response.statusText;
     try {
       errMessage = await response.text();
-    } catch (err) { }
+    } catch (err) {}
 
     if (errMessage) {
       switch (errMessage) {
@@ -518,10 +518,10 @@ class CloudSdkAPI {
 
   async resetEnv(wait) {
     await this._checkRDE();
-    await this._waitForEnv();
+    await this._waitForCMStatus();
     await this._resetEnv();
     if (wait) {
-      return await this._waitForEnv();
+      return await this._waitForCMStatus();
     }
   }
 
@@ -529,7 +529,7 @@ class CloudSdkAPI {
     await this._cloudManagerClient.doPut(`/reset`);
   }
 
-  async _waitForEnv() {
+  async _waitForCMStatus() {
     const json = await this._waitForJson(
       (status) => status.status === 'ready' || status.status === 'reset_failed',
       async () => await this._cloudManagerClient.doGet('')

--- a/src/lib/cloud-sdk-api.js
+++ b/src/lib/cloud-sdk-api.js
@@ -328,7 +328,7 @@ class CloudSdkAPI {
     let errMessage = response.statusText;
     try {
       errMessage = await response.text();
-    } catch (err) {}
+    } catch (err) { }
 
     if (errMessage) {
       switch (errMessage) {
@@ -518,10 +518,10 @@ class CloudSdkAPI {
 
   async resetEnv(wait) {
     await this._checkRDE();
-    await this._waitForEnvReady();
+    await this._waitForEnv();
     await this._resetEnv();
     if (wait) {
-      await this._waitForEnvReady();
+      return await this._waitForEnv();
     }
   }
 
@@ -529,11 +529,12 @@ class CloudSdkAPI {
     await this._cloudManagerClient.doPut(`/reset`);
   }
 
-  async _waitForEnvReady() {
-    await this._waitForJson(
-      (status) => status.status === 'ready',
+  async _waitForEnv() {
+    const json = await this._waitForJson(
+      (status) => status.status === 'ready' || status.status === 'reset_failed',
       async () => await this._cloudManagerClient.doGet('')
     );
+    return json.status;
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When a reset fails, i.e. timeouts after 45min, indicate this to the user the same way the cloud manager UI does it.

On Error:
```
$ aio aem rde reset
Running aem:rde:reset on cm-pXXXX-eXXXXX
Reset cm-pXXXX-eXXXX
Failed to reset the environment.
```

On Error (json):
```
$ aio aem rde reset --json
{
  "programId": "XXXX",
  "environmentId": "XXXXX",
  "status": "reset_failed"
}
```

On Success, backwards compatible:
```
$ aio aem rde reset --json
{
  "programId": "84002",
  "environmentId": "273424",
  "status": "reset"
}
```

## Motivation and Context

It could happen that the reset job on the cluster got stuck and the client hang for hours, without any information to the user.

## How Has This Been Tested?

Manually specify a timeout on the cluster to fail the job after a couple of seconds to trigger a failed reset.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
==> experience-manager-cloud-service.en/pull/5985
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
