### PR TITLE
add trace option

### DIFF
--- a/src/commands/aem/rde/logs.js
+++ b/src/commands/aem/rde/logs.js
@@ -186,11 +186,17 @@ class LogsCommand extends BaseCommand {
       }
       // check if there are values for the name key
       // formats the flags in the right way to pass them to the request
-      if (flags.info || flags.debug || flags.warn || flags.error) {
+      if (
+        flags.info ||
+        flags.debug ||
+        flags.warn ||
+        flags.error ||
+        flags.trace
+      ) {
         const namesArray = [];
-        // flags?.trace?.forEach((logger) => {
-        //   namesArray.push({ logger, level: 'TRACE' });
-        // });
+        flags?.trace?.forEach((logger) => {
+          namesArray.push({ logger, level: 'TRACE' });
+        });
         flags?.debug?.forEach((logger) => {
           namesArray.push({ logger, level: 'DEBUG' });
         });
@@ -306,11 +312,14 @@ Object.assign(LogsCommand, {
       helpValue: `<logback format definition>`,
       helpGroup: 'format and color',
     }),
-    // trace: Flags.string({
-    //   description: `Optional logger on TRACE level.`,
-    //   multiple: true,
-    //   required: false,
-    // }),
+    trace: Flags.string({
+      char: 't',
+      description: `Optional logger on TRACE level.`,
+      multiple: true,
+      required: false,
+      helpValue: `<package or class name>`,
+      helpGroup: 'level',
+    }),
     debug: Flags.string({
       char: 'd',
       description: `Optional logger on DEBUG level.`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds trace option

````
$ aio aem rde logs --help
...
LEVEL FLAGS
  -d, --debug=<package or class name>...  Optional logger on DEBUG level.
  -e, --error=<package or class name>...  Optional logger on ERROR level.
  -i, --info=<package or class name>...   Optional logger on INFO level.
  -t, --trace=<package or class name>...  Optional logger on TRACE level.
  -w, --warn=<package or class name>...   Optional logger on WARN level.

````
## Related Issue
FIXES #103 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

using an RDE, added trace logs to aem-guides-wknd

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/2f4fd3d6-4648-46ff-a061-71adf9fea80c)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
